### PR TITLE
Harden trust list ingestion pipeline

### DIFF
--- a/app/src/androidTest/java/com/laurelid/di/TestVerifierModule.kt
+++ b/app/src/androidTest/java/com/laurelid/di/TestVerifierModule.kt
@@ -94,7 +94,7 @@ private class FakeTrustListRepository(
 
     override fun cached(nowMillis: Long): Snapshot? = snapshot
 
-    override fun updateEndpoint(newApi: TrustListApi, newBaseUrl: String) {
+    override suspend fun updateEndpoint(newApi: TrustListApi, newBaseUrl: String) {
         baseUrl = newBaseUrl
     }
 

--- a/app/src/main/java/com/laurelid/network/TrustListEndpointPolicy.kt
+++ b/app/src/main/java/com/laurelid/network/TrustListEndpointPolicy.kt
@@ -78,11 +78,28 @@ object TrustListEndpointPolicy {
         if (trimmed.isNullOrEmpty()) {
             return null
         }
+        return normalizeOrNull(trimmed)
+    }
+
+    internal fun normalizeOrNull(candidate: String?): String? {
+        val trimmed = candidate?.trim()
+        if (trimmed.isNullOrEmpty()) {
+            return null
+        }
         return try {
             normalize(trimmed)
         } catch (_: IllegalArgumentException) {
             null
         }
+    }
+
+    internal fun endpointsMatch(first: String?, second: String?): Boolean {
+        val normalizedFirst = normalizeOrNull(first)
+        val normalizedSecond = normalizeOrNull(second)
+        if (normalizedFirst == null || normalizedSecond == null) {
+            return normalizedFirst == null && normalizedSecond == null
+        }
+        return normalizedFirst == normalizedSecond
     }
 
     private fun normalize(candidate: String): String {

--- a/app/src/test/java/com/laurelid/network/TrustListEndpointPolicyTest.kt
+++ b/app/src/test/java/com/laurelid/network/TrustListEndpointPolicyTest.kt
@@ -3,6 +3,7 @@ package com.laurelid.network
 import com.laurelid.BuildConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -79,5 +80,20 @@ class TrustListEndpointPolicyTest {
                 // expected
             }
         }
+    }
+
+    @Test
+    fun `normalize or null returns null for invalid input`() {
+        assertNull(TrustListEndpointPolicy.normalizeOrNull(""))
+        assertNull(TrustListEndpointPolicy.normalizeOrNull("not a url"))
+    }
+
+    @Test
+    fun `endpoints match compares normalized values`() {
+        val default = TrustListEndpointPolicy.defaultBaseUrl
+        val extraSlash = "$default/"
+        assertTrue(TrustListEndpointPolicy.endpointsMatch(default, extraSlash))
+        assertFalse(TrustListEndpointPolicy.endpointsMatch(default, "https://example.com"))
+        assertTrue(TrustListEndpointPolicy.endpointsMatch(null, null))
     }
 }


### PR DESCRIPTION
## Summary
- validate cached trust-list payloads by persisting the signed response, re-verifying on load, and scoping caches to their endpoint
- move trust-list endpoint switching into a background coroutine and clear caches when the endpoint changes
- add explicit retry telemetry with exponential backoff metrics and expand unit coverage for cache validation and endpoint policies

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc588ff14832f9553285e144d9503