### PR TITLE
Secure trust list cache storage

### DIFF
--- a/app/src/main/java/com/laurelid/network/TrustListCacheStorage.kt
+++ b/app/src/main/java/com/laurelid/network/TrustListCacheStorage.kt
@@ -1,0 +1,83 @@
+package com.laurelid.network
+
+import android.content.Context
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.MasterKey
+import com.laurelid.util.Logger
+import java.io.File
+import java.io.IOException
+import java.security.GeneralSecurityException
+
+internal interface TrustListCacheStorage {
+    fun read(): String?
+    fun write(contents: String)
+    fun delete()
+}
+
+internal class EncryptedTrustListCacheStorage(
+    private val context: Context,
+    private val file: File,
+) : TrustListCacheStorage {
+
+    private val masterKey by lazy {
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+    }
+
+    override fun read(): String? {
+        if (!file.exists()) {
+            return null
+        }
+        return try {
+            createEncryptedFile().openFileInput().bufferedReader().use { reader ->
+                reader.readText()
+            }
+        } catch (security: GeneralSecurityException) {
+            Logger.e(TAG, "Unable to decrypt trust list cache", security)
+            delete()
+            null
+        } catch (ioException: IOException) {
+            Logger.e(TAG, "Unable to read encrypted trust list cache", ioException)
+            null
+        }
+    }
+
+    override fun write(contents: String) {
+        try {
+            file.parentFile?.let { parent ->
+                if (!parent.exists() && !parent.mkdirs()) {
+                    Logger.w(TAG, "Unable to create trust list cache directory")
+                }
+            }
+            createEncryptedFile().openFileOutput().use { output ->
+                output.write(contents.toByteArray(Charsets.UTF_8))
+            }
+        } catch (security: GeneralSecurityException) {
+            Logger.e(TAG, "Unable to encrypt trust list cache", security)
+            throw IOException("Unable to persist trust list cache", security)
+        } catch (ioException: IOException) {
+            Logger.e(TAG, "Unable to persist encrypted trust list cache", ioException)
+            throw ioException
+        }
+    }
+
+    override fun delete() {
+        if (file.exists() && !file.delete()) {
+            Logger.w(TAG, "Unable to delete trust list cache file")
+        }
+    }
+
+    private fun createEncryptedFile(): EncryptedFile {
+        return EncryptedFile.Builder(
+            context,
+            file,
+            masterKey,
+            EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB,
+        ).build()
+    }
+
+    companion object {
+        private const val TAG = "EncryptedTrustCache"
+    }
+}

--- a/app/src/test/java/com/laurelid/auth/VerifierServiceTest.kt
+++ b/app/src/test/java/com/laurelid/auth/VerifierServiceTest.kt
@@ -50,6 +50,7 @@ class VerifierServiceTest {
             assertTrue(result.success)
             assertEquals(scenario.issuer, result.issuer)
             assertEquals(null, result.error)
+            assertEquals(false, result.trustStale)
         }
     }
 
@@ -81,6 +82,7 @@ class VerifierServiceTest {
             assertEquals(VerifierService.ERROR_TRUST_LIST_UNAVAILABLE, result.error)
             assertNull(result.issuer)
             assertNull(result.subjectDid)
+            assertEquals(false, result.trustStale)
         }
     }
 
@@ -143,6 +145,7 @@ class VerifierServiceTest {
             assertTrue(result.success)
             assertEquals(scenario.issuer, result.issuer)
             assertEquals(null, result.error)
+            assertEquals(true, result.trustStale)
         }
     }
 

--- a/app/src/test/java/com/laurelid/network/TrustListTestAuthority.kt
+++ b/app/src/test/java/com/laurelid/network/TrustListTestAuthority.kt
@@ -40,6 +40,7 @@ object TrustListTestAuthority {
         freshLifetimeMillis: Long = TimeUnit.HOURS.toMillis(12),
         staleLifetimeMillis: Long = TimeUnit.DAYS.toMillis(3),
         revokedSerials: Set<String> = emptySet(),
+        version: Long = 1L,
     ): TrustListResponse {
         val manifestJson = JSONObject().apply {
             put("entries", JSONObject(entries))
@@ -53,6 +54,7 @@ object TrustListTestAuthority {
                 }
             }
             put("revokedSerialNumbers", revokedArray)
+            put("version", version)
         }
 
         val manifestBytes = manifestJson.toString().toByteArray(Charsets.UTF_8)


### PR DESCRIPTION
## Summary
- encrypt the persisted trust list cache with EncryptedFile and verify checksum + manifest version before serving cached data
- surface manifest version from the verifier, enforce stale TTL handling, and propagate stale flags into verification telemetry
- extend unit coverage for offline cold start, warm cache reuse, checksum/version tampering, and stale flag reporting

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de07d759e8832f84e85445a00a2b9e