### PR TITLE
Add device-owner enforcement and kiosk hardening

### DIFF
--- a/DeviceOwnerSetup.md
+++ b/DeviceOwnerSetup.md
@@ -27,7 +27,7 @@ Run the helper script from the repository root:
 
 The script performs the following configuration:
 
-- Promotes `com.laurelid/.DeviceAdminReceiver` to **device owner**.
+- Promotes `com.laurelid/.kiosk.LaurelIdDeviceAdminReceiver` to **device owner**.
 - Adds the app to the lock-task allowlist and enables key system dialogs
   (`KEYGUARD`, `SYSTEM_INFO`, `NOTIFICATIONS`, `GLOBAL_ACTIONS`) so permission
   prompts and error sheets can still surface while pinned.
@@ -57,6 +57,9 @@ After the device reboots:
    The dialog should appear despite lock task being active.
 4. Allow the device to idle for several minutes; it should remain responsive to
    NFC taps or manual refreshes.
+5. If you accidentally sideload a **release** build before provisioning, the
+   app will crash on launch with an "app must be device owner" error. Run the
+   provisioning script above and relaunch to clear the guardrail.
 
 ## Uninstall / Reset Instructions
 
@@ -65,7 +68,7 @@ ADB commands:
 
 ```bash
 adb wait-for-device
-adb shell dpm remove-active-admin --user 0 "com.laurelid/.DeviceAdminReceiver"
+adb shell dpm remove-active-admin --user 0 "com.laurelid/.kiosk.LaurelIdDeviceAdminReceiver"
 adb shell cmd package clear-home-activity
 adb shell cmd deviceidle whitelist -com.laurelid
 adb shell am set-inactive com.laurelid true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,19 @@
             android:foregroundServiceType="dataSync"
             android:stopWithTask="false" />
 
+        <receiver
+            android:name="com.laurelid.kiosk.LaurelIdDeviceAdminReceiver"
+            android:description="@string/app_name"
+            android:exported="true"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin_receiver" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/laurelid/LaurelIdApp.kt
+++ b/app/src/main/java/com/laurelid/LaurelIdApp.kt
@@ -1,6 +1,7 @@
 package com.laurelid
 
 import android.app.Application
+import com.laurelid.kiosk.KioskDeviceOwnerManager
 import com.laurelid.kiosk.KioskWatchdogService
 import com.laurelid.observability.IEventExporter
 import com.laurelid.observability.StructuredEventLogger
@@ -28,6 +29,7 @@ class LaurelIdApp : Application() {
         super.onCreate()
         Logger.i("App", "LaurelID kiosk application initialized")
         StructuredEventLogger.registerExporter(eventExporter)
+        KioskDeviceOwnerManager.enforcePolicies(this)
         KioskWatchdogService.start(this)
         appScope.launch {
             logManager.purgeLegacyLogs()

--- a/app/src/main/java/com/laurelid/kiosk/KioskDeviceOwnerManager.kt
+++ b/app/src/main/java/com/laurelid/kiosk/KioskDeviceOwnerManager.kt
@@ -1,0 +1,71 @@
+package com.laurelid.kiosk
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import com.laurelid.BuildConfig
+import com.laurelid.util.Logger
+
+/**
+ * Centralizes the device-owner policies needed for kiosk mode.
+ */
+object KioskDeviceOwnerManager {
+
+    private const val TAG = "KioskDeviceOwner"
+
+    fun enforcePolicies(context: Context) {
+        val dpm = context.getSystemService(DevicePolicyManager::class.java)
+        if (dpm == null) {
+            Logger.w(TAG, "DevicePolicyManager unavailable; kiosk policies cannot be applied")
+            if (!BuildConfig.DEBUG) {
+                throw IllegalStateException("Release builds require device owner access")
+            }
+            return
+        }
+        val component = ComponentName(context, LaurelIdDeviceAdminReceiver::class.java)
+        val packageName = context.packageName
+        val isDeviceOwner = try {
+            dpm.isDeviceOwnerApp(packageName)
+        } catch (e: SecurityException) {
+            Logger.e(TAG, "Unable to determine device owner state", e)
+            false
+        }
+
+        if (isDeviceOwner) {
+            ensureLockTaskPolicies(dpm, component, packageName)
+        } else {
+            Logger.w(TAG, "App is not device owner; kiosk protections are degraded")
+        }
+
+        if (!isDeviceOwner && !BuildConfig.DEBUG) {
+            throw IllegalStateException("Release builds require the app to be device owner")
+        }
+    }
+
+    private fun ensureLockTaskPolicies(
+        dpm: DevicePolicyManager,
+        admin: ComponentName,
+        packageName: String,
+    ) {
+        try {
+            dpm.setLockTaskPackages(admin, arrayOf(packageName))
+        } catch (e: SecurityException) {
+            Logger.e(TAG, "Failed to set lock task packages", e)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            var features = DevicePolicyManager.LOCK_TASK_FEATURE_KEYGUARD or
+                DevicePolicyManager.LOCK_TASK_FEATURE_NOTIFICATIONS or
+                DevicePolicyManager.LOCK_TASK_FEATURE_SYSTEM_INFO
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                features = features or DevicePolicyManager.LOCK_TASK_FEATURE_GLOBAL_ACTIONS
+            }
+            try {
+                dpm.setLockTaskFeatures(admin, features)
+            } catch (e: SecurityException) {
+                Logger.e(TAG, "Failed to set lock task features", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/laurelid/kiosk/LaurelIdDeviceAdminReceiver.kt
+++ b/app/src/main/java/com/laurelid/kiosk/LaurelIdDeviceAdminReceiver.kt
@@ -1,0 +1,43 @@
+package com.laurelid.kiosk
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import com.laurelid.util.Logger
+
+/**
+ * Device admin receiver required so the kiosk app can become a device owner.
+ * Only logs lifecycle callbacks for observability – all policy work happens
+ * in [KioskDeviceOwnerManager].
+ */
+class LaurelIdDeviceAdminReceiver : DeviceAdminReceiver() {
+
+    override fun onEnabled(context: Context, intent: Intent) {
+        super.onEnabled(context, intent)
+        Logger.i(TAG, "Device admin enabled for ${componentName(context)}")
+    }
+
+    override fun onDisabled(context: Context, intent: Intent) {
+        super.onDisabled(context, intent)
+        Logger.w(TAG, "Device admin disabled for ${componentName(context)}")
+    }
+
+    override fun onLockTaskModeEntering(context: Context, intent: Intent, pkg: String) {
+        super.onLockTaskModeEntering(context, intent, pkg)
+        Logger.i(TAG, "Lock task mode entered for package $pkg")
+    }
+
+    override fun onLockTaskModeExiting(context: Context, intent: Intent) {
+        super.onLockTaskModeExiting(context, intent)
+        Logger.i(TAG, "Lock task mode exited")
+    }
+
+    private fun componentName(context: Context): ComponentName {
+        return ComponentName(context, javaClass)
+    }
+
+    companion object {
+        private const val TAG = "DeviceAdminReceiver"
+    }
+}

--- a/app/src/main/java/com/laurelid/ui/AdminActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/AdminActivity.kt
@@ -16,6 +16,7 @@ import com.laurelid.config.AdminPinManager
 import com.laurelid.config.ConfigManager
 import com.laurelid.config.EncryptedAdminPinStorage
 import com.laurelid.integrity.PlayIntegrityGate
+import com.laurelid.kiosk.KioskWatchdogService
 import com.laurelid.network.TrustListEndpointPolicy
 import com.laurelid.util.KioskUtil
 import kotlinx.coroutines.launch
@@ -46,6 +47,18 @@ class AdminActivity : AppCompatActivity() {
                 bindConfig()
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        KioskUtil.prepareForLockscreen(this)
+        KioskUtil.setImmersiveMode(window)
+        KioskWatchdogService.notifyScannerVisible(true)
+    }
+
+    override fun onPause() {
+        KioskWatchdogService.notifyScannerVisible(false)
+        super.onPause()
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/laurelid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/LoginActivity.kt
@@ -3,6 +3,7 @@ package com.laurelid.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.laurelid.R
+import com.laurelid.kiosk.KioskWatchdogService
 import com.laurelid.util.KioskUtil
 
 class LoginActivity : AppCompatActivity() {
@@ -11,6 +12,18 @@ class LoginActivity : AppCompatActivity() {
         setContentView(R.layout.activity_login)
         KioskUtil.applyKioskDecor(window)
         KioskUtil.blockBackPress(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        KioskUtil.prepareForLockscreen(this)
+        KioskUtil.setImmersiveMode(window)
+        KioskWatchdogService.notifyScannerVisible(true)
+    }
+
+    override fun onPause() {
+        KioskWatchdogService.notifyScannerVisible(false)
+        super.onPause()
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/laurelid/ui/ResultActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ResultActivity.kt
@@ -15,6 +15,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.laurelid.R
 import com.laurelid.data.VerificationResult // Ensure this is Parcelable and has the necessary fields
+import com.laurelid.kiosk.KioskWatchdogService
 import com.laurelid.util.KioskUtil
 import com.laurelid.util.Logger // Added for logging potential issues
 
@@ -51,6 +52,18 @@ class ResultActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         handler.removeCallbacksAndMessages(null)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        KioskUtil.prepareForLockscreen(this)
+        KioskUtil.setImmersiveMode(window)
+        KioskWatchdogService.notifyScannerVisible(true)
+    }
+
+    override fun onPause() {
+        KioskWatchdogService.notifyScannerVisible(false)
+        super.onPause()
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
@@ -196,9 +196,10 @@ class ScannerActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         if (nfcAdapter != null && !currentConfig.demoMode) {
-             disableForegroundDispatch()
+            disableForegroundDispatch()
         }
         stopDemoMode()
+        KioskWatchdogService.notifyScannerVisible(false)
         // No need to call stopCamera() explicitly if using ProcessCameraProvider,
         // as it's lifecycle-aware. It will unbind when the lifecycle stops.
     }

--- a/app/src/main/res/xml/device_admin_receiver.xml
+++ b/app/src/main/res/xml/device_admin_receiver.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <force-lock />
+        <reset-password />
+        <wipe-data />
+    </uses-policies>
+</device-admin>

--- a/docs/kiosk-mode.md
+++ b/docs/kiosk-mode.md
@@ -1,0 +1,55 @@
+# LaurelID Kiosk Mode Architecture
+
+This document explains how the Android client enforces kiosk behavior when it
+is promoted to **device owner**.
+
+## Device Owner Receiver
+
+* `com.laurelid.kiosk.LaurelIdDeviceAdminReceiver` is registered in the
+  manifest as a `DeviceAdminReceiver`. It only logs lifecycle callbacks but is
+  required so that Android accepts the app as a device owner.
+* A companion XML descriptor (`res/xml/device_admin_receiver.xml`) advertises
+  the admin policies the app may request (lock task, password reset, and wipe).
+
+## Policy Bootstrap
+
+* `LaurelIdApp` calls `KioskDeviceOwnerManager.enforcePolicies()` during app
+  start-up.
+* The helper checks `DevicePolicyManager.isDeviceOwnerApp()`. Release builds
+  throw an `IllegalStateException` if the app is *not* the active device owner,
+  preventing misconfigured production installs.
+* When ownership is confirmed the helper:
+  * Adds the LaurelID package to the lock-task allowlist.
+  * Enables lock-task features so key system surfaces (keyguard, notifications,
+    system info, and global actions) continue to work while the task is pinned.
+
+## Lock Task + Immersive UI
+
+* `ScannerActivity` and every kiosk surface (`LoginActivity`, `ResultActivity`,
+  `AdminActivity`) call the `KioskUtil` helpers to keep the screen on, dismiss
+  the keyguard, and apply immersive flags each time they resume or regain focus.
+* `ScannerActivity` re-enters lock task mode on every resume and whenever the
+  window regains focus.
+
+## Watchdog Relaunch
+
+* `KioskWatchdogService` runs as a foreground service. Activities mark
+  themselves visible via `notifyScannerVisible(true/false)` in `onResume` and
+  `onPause`.
+* If the watchdog observes that no kiosk activity has been visible for an
+  entire interval it relaunches `ScannerActivity`, ensuring recovery after a
+  crash, user-initiated HOME press, or an unexpected overlay.
+* The service starts on boot and whenever the app process launches so it can
+  resurrect the kiosk experience automatically.
+
+## Provisioning Script
+
+* `scripts/provision_device_owner.sh` automates the ADB sequence required to
+  provision a dedicated device:
+  * `dpm set-device-owner com.laurelid/.kiosk.LaurelIdDeviceAdminReceiver`
+  * `dpm set-lock-task-packages` / `set-lock-task-features`
+  * Launcher binding, dialog allowlists, standby/idle relaxations, and a final
+    reboot.
+
+Refer to [DeviceOwnerSetup.md](../DeviceOwnerSetup.md) for step-by-step usage
+instructions.

--- a/scripts/provision_device_owner.sh
+++ b/scripts/provision_device_owner.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PACKAGE="com.laurelid"
-ADMIN_COMPONENT="com.laurelid/.DeviceAdminReceiver"
+ADMIN_COMPONENT="com.laurelid/.kiosk.LaurelIdDeviceAdminReceiver"
 LAUNCHER_ACTIVITY="com.laurelid/.ui.ScannerActivity"
 ADB_BIN="${ADB:-adb}"
 
@@ -25,10 +25,10 @@ fi
 run_adb shell dpm set-device-owner "${ADMIN_COMPONENT}"
 
 # Allow the kiosk app to enter lock task (screen pinning) mode automatically.
-run_adb shell dpm set-lock-task-packages ${PACKAGE} ${PACKAGE}
+run_adb shell dpm set-lock-task-packages "${ADMIN_COMPONENT}" ${PACKAGE}
 
 # Whitelist system surfaces/dialogs needed for camera prompts, intents, etc.
-run_adb shell dpm set-lock-task-features ${PACKAGE} KEYGUARD SYSTEM_INFO NOTIFICATIONS GLOBAL_ACTIONS
+run_adb shell dpm set-lock-task-features "${ADMIN_COMPONENT}" KEYGUARD SYSTEM_INFO NOTIFICATIONS GLOBAL_ACTIONS
 
 # Ensure Android treats the scanner activity as the launcher so it boots on startup.
 run_adb shell cmd package set-home-activity "${LAUNCHER_ACTIVITY}"


### PR DESCRIPTION
## Summary
- register a device admin receiver and enforce device-owner lock task policies during app start
- extend kiosk activities and watchdog integration so immersive mode and lock task resume automatically
- refresh the provisioning script and add documentation covering the kiosk/device-owner architecture

## Testing
- ./gradlew :app:lintDebug *(fails: task name is ambiguous for the multi-variant module)*
- ./gradlew :app:lintStagingDebug *(fails: Android SDK is not available in the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68de1629942c832faa9a6327f488ab9c