### PR TITLE
Refactor scanner flow into modular components

### DIFF
--- a/app/src/main/java/com/laurelid/auth/ISO18013Parser.kt
+++ b/app/src/main/java/com/laurelid/auth/ISO18013Parser.kt
@@ -5,11 +5,13 @@ import com.laurelid.auth.deviceengagement.DeviceEngagementTransportFactory
 import com.laurelid.auth.deviceengagement.TransportFactory
 import com.laurelid.auth.deviceengagement.TransportMessage
 import com.laurelid.util.Logger
+import javax.inject.Inject
 
 /**
  * Parser for ISO 18013-5 mobile driving licence engagements.
  */
-class ISO18013Parser(
+
+class ISO18013Parser @Inject constructor(
     private val engagementParser: DeviceEngagementParser = DeviceEngagementParser(),
     private val transportFactory: TransportFactory = DeviceEngagementTransportFactory(),
     private val deviceResponseParser: DeviceResponseParser = DeviceResponseParser(

--- a/app/src/main/java/com/laurelid/di/ScannerModule.kt
+++ b/app/src/main/java/com/laurelid/di/ScannerModule.kt
@@ -1,0 +1,20 @@
+package com.laurelid.di
+
+import com.laurelid.scanner.CredentialParser
+import com.laurelid.scanner.DefaultCredentialParser
+import com.laurelid.scanner.VerificationExecutor
+import com.laurelid.scanner.VerificationOrchestrator
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface ScannerModule {
+    @Binds
+    fun bindCredentialParser(impl: DefaultCredentialParser): CredentialParser
+
+    @Binds
+    fun bindVerificationExecutor(impl: VerificationOrchestrator): VerificationExecutor
+}

--- a/app/src/main/java/com/laurelid/pos/TransactionManager.kt
+++ b/app/src/main/java/com/laurelid/pos/TransactionManager.kt
@@ -3,7 +3,9 @@ package com.laurelid.pos
 import com.laurelid.data.VerificationResult
 import com.laurelid.util.Logger
 
-class TransactionManager {
+import javax.inject.Inject
+
+class TransactionManager @Inject constructor() {
     fun record(result: VerificationResult) {
         // TODO: Integrate with local printer/POS systems once hardware is finalized.
         Logger.d(TAG, "Recorded verification event: success=${result.success}")

--- a/app/src/main/java/com/laurelid/scanner/CredentialParser.kt
+++ b/app/src/main/java/com/laurelid/scanner/CredentialParser.kt
@@ -1,0 +1,18 @@
+package com.laurelid.scanner
+
+import com.laurelid.auth.ISO18013Parser
+import com.laurelid.auth.ParsedMdoc
+import javax.inject.Inject
+
+interface CredentialParser {
+    fun fromQr(payload: String): ParsedMdoc
+    fun fromNfc(bytes: ByteArray): ParsedMdoc
+}
+
+class DefaultCredentialParser @Inject constructor(
+    private val parser: ISO18013Parser,
+) : CredentialParser {
+    override fun fromQr(payload: String): ParsedMdoc = parser.parseFromQrPayload(payload)
+
+    override fun fromNfc(bytes: ByteArray): ParsedMdoc = parser.parseFromNfc(bytes)
+}

--- a/app/src/main/java/com/laurelid/scanner/ScannerUiState.kt
+++ b/app/src/main/java/com/laurelid/scanner/ScannerUiState.kt
@@ -1,0 +1,34 @@
+package com.laurelid.scanner
+
+import androidx.annotation.StringRes
+import com.laurelid.R
+import com.laurelid.data.VerificationResult
+
+/**
+ * Immutable snapshot of the scanner UI.
+ */
+data class ScannerUiState(
+    val phase: Phase = Phase.Scanning,
+    val isProcessing: Boolean = false,
+    val demoMode: Boolean = false,
+    val result: VerificationResult? = null,
+    @StringRes val errorMessageRes: Int? = null,
+) {
+    enum class Phase { Scanning, Verifying, Result }
+
+    val statusTextRes: Int
+        @StringRes get() = when (phase) {
+            Phase.Scanning -> R.string.scanner_status_scanning
+            Phase.Verifying -> R.string.scanner_status_verifying
+            Phase.Result -> R.string.scanner_status_ready
+        }
+
+    val hintTextRes: Int
+        @StringRes get() = when (phase) {
+            Phase.Scanning -> R.string.scanner_hint
+            Phase.Verifying -> R.string.scanner_status_verifying
+            Phase.Result -> R.string.scanner_status_ready
+        }
+
+    val showProgress: Boolean get() = phase == Phase.Verifying
+}

--- a/app/src/main/java/com/laurelid/scanner/ScannerViewModel.kt
+++ b/app/src/main/java/com/laurelid/scanner/ScannerViewModel.kt
@@ -1,0 +1,113 @@
+package com.laurelid.scanner
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.laurelid.auth.MdocParseException
+import com.laurelid.auth.ParsedMdoc
+import com.laurelid.config.AdminConfig
+import com.laurelid.util.Logger
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class ScannerViewModel @Inject constructor(
+    private val credentialParser: CredentialParser,
+    private val verificationExecutor: VerificationExecutor,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ScannerUiState())
+    val state: StateFlow<ScannerUiState> = _state
+
+    private var verificationJob: Job? = null
+    private var configSnapshot: AdminConfig = AdminConfig()
+
+    fun updateConfig(config: AdminConfig) {
+        configSnapshot = config
+        _state.update { it.copy(demoMode = config.demoMode) }
+    }
+
+    fun submitQrPayload(payload: String, demoPayload: Boolean = false) {
+        startVerification(demoPayload) { credentialParser.fromQr(payload) }
+    }
+
+    fun submitNfcPayload(payload: ByteArray) {
+        startVerification(demoPayload = false) { credentialParser.fromNfc(payload) }
+    }
+
+    fun submitDemoPayload(payloadProvider: () -> String) {
+        if (!_state.value.demoMode) return
+        submitQrPayload(payloadProvider.invoke(), demoPayload = true)
+    }
+
+    fun onResultConsumed() {
+        val demoMode = _state.value.demoMode
+        _state.update { ScannerUiState(demoMode = demoMode) }
+    }
+
+    fun onErrorConsumed() {
+        _state.update { it.copy(errorMessageRes = null) }
+    }
+
+    private fun startVerification(demoPayload: Boolean, parser: suspend () -> ParsedMdoc) {
+        if (_state.value.isProcessing) return
+        verificationJob?.cancel()
+        verificationJob = viewModelScope.launch {
+            _state.update { it.copy(phase = ScannerUiState.Phase.Verifying, isProcessing = true, errorMessageRes = null) }
+            val parsed = runCatching { withContext(dispatcher) { parser() } }
+            val verificationResult = parsed.fold(
+                onSuccess = { parsedMdoc ->
+                    runCatching {
+                        verificationExecutor.verify(parsedMdoc, configSnapshot, demoPayload)
+                    }.getOrElse { throwable ->
+                        verificationExecutor.buildClientFailureResult(parsedMdoc)
+                            .also { handleError(throwable) }
+                    }
+                },
+                onFailure = { throwable ->
+                    handleError(throwable)
+                    null
+                }
+            )
+            if (verificationResult != null) {
+                _state.update {
+                    it.copy(
+                        phase = ScannerUiState.Phase.Result,
+                        isProcessing = false,
+                        result = verificationResult,
+                    )
+                }
+            } else {
+                _state.update {
+                    it.copy(
+                        phase = ScannerUiState.Phase.Scanning,
+                        isProcessing = false,
+                        errorMessageRes = ERROR_MESSAGE,
+                    )
+                }
+            }
+            verificationJob = null
+        }
+    }
+
+    private fun handleError(error: Throwable) {
+        if (error is MdocParseException) {
+            Logger.w(TAG, "Credential parsing failed: ${error.error.detail}", error)
+        } else {
+            Logger.e(TAG, "Unexpected verification error", error)
+        }
+    }
+
+    companion object {
+        private const val ERROR_MESSAGE = com.laurelid.R.string.result_details_error_unknown
+        private const val TAG = "ScannerViewModel"
+    }
+}

--- a/app/src/main/java/com/laurelid/scanner/VerificationOrchestrator.kt
+++ b/app/src/main/java/com/laurelid/scanner/VerificationOrchestrator.kt
@@ -1,0 +1,114 @@
+package com.laurelid.scanner
+
+import android.content.Context
+import com.laurelid.auth.ParsedMdoc
+import com.laurelid.auth.VerifierService
+import com.laurelid.auth.WalletVerifier
+import com.laurelid.config.AdminConfig
+import com.laurelid.data.VerificationResult
+import com.laurelid.db.DbModule
+import com.laurelid.db.VerificationDao
+import com.laurelid.db.VerificationEntity
+import com.laurelid.pos.TransactionManager
+import com.laurelid.util.LogManager
+import com.laurelid.util.Logger
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+interface VerificationExecutor {
+    suspend fun verify(parsedMdoc: ParsedMdoc, config: AdminConfig, demoPayloadUsed: Boolean): VerificationResult
+    fun buildClientFailureResult(parsedMdoc: ParsedMdoc): VerificationResult
+}
+
+@Singleton
+open class VerificationOrchestrator @Inject constructor(
+    @ApplicationContext context: Context,
+    private val walletVerifier: WalletVerifier,
+    private val logManager: LogManager,
+    private val transactionManager: TransactionManager,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : VerificationExecutor {
+    private val verificationDao: VerificationDao = DbModule.provideVerificationDao(context)
+
+    override suspend fun verify(
+        parsedMdoc: ParsedMdoc,
+        config: AdminConfig,
+        demoPayloadUsed: Boolean,
+    ): VerificationResult {
+        val refreshMillis = TimeUnit.MINUTES.toMillis(config.trustRefreshIntervalMinutes.toLong())
+
+        val rawResult = runCatching {
+            withContext(dispatcher) { walletVerifier.verify(parsedMdoc, refreshMillis) }
+        }.getOrElse { throwable ->
+            Logger.e(TAG, "Verification failed", throwable)
+            buildClientFailureResult(parsedMdoc)
+        }
+
+        val sanitized = sanitizeResult(rawResult)
+        persistResult(sanitized, config, demoPayloadUsed)
+        transactionManager.record(sanitized)
+        return sanitized
+    }
+
+    private suspend fun persistResult(
+        result: VerificationResult,
+        config: AdminConfig,
+        demoPayloadUsed: Boolean,
+    ) {
+        withContext(dispatcher) {
+            val previous = verificationDao.mostRecent()
+            val successCount = (previous?.totalSuccessCount ?: 0) + if (result.success) 1 else 0
+            val failureCount = (previous?.totalFailureCount ?: 0) + if (result.success) 0 else 1
+            val over21Count = (previous?.totalAgeOver21Count ?: 0) + if (result.ageOver21 == true) 1 else 0
+            val under21Count = (previous?.totalAgeUnder21Count ?: 0) + if (result.ageOver21 == false) 1 else 0
+            val demoCount = (previous?.totalDemoModeCount ?: 0) + if (demoPayloadUsed) 1 else 0
+
+            val entity = VerificationEntity(
+                success = result.success,
+                ageOver21 = result.ageOver21 == true,
+                demoMode = demoPayloadUsed,
+                error = result.error,
+                tsMillis = System.currentTimeMillis(),
+                totalSuccessCount = successCount,
+                totalFailureCount = failureCount,
+                totalAgeOver21Count = over21Count,
+                totalAgeUnder21Count = under21Count,
+                totalDemoModeCount = demoCount,
+            )
+            verificationDao.insert(entity)
+            logManager.appendVerification(result, config, demoPayloadUsed)
+        }
+    }
+
+    override fun buildClientFailureResult(parsedMdoc: ParsedMdoc): VerificationResult {
+        return VerificationResult(
+            success = false,
+            ageOver21 = parsedMdoc.ageOver21,
+            issuer = null,
+            subjectDid = null,
+            docType = parsedMdoc.docType,
+            error = VerifierService.ERROR_CLIENT_EXCEPTION,
+            trustStale = null,
+        )
+    }
+
+    fun sanitizeResult(result: VerificationResult): VerificationResult {
+        if (result.success) {
+            return result
+        }
+        return result.copy(
+            issuer = null,
+            subjectDid = null,
+            error = VerifierService.sanitizeReasonCode(result.error),
+        )
+    }
+
+    companion object {
+        private const val TAG = "VerificationOrchestrator"
+    }
+}

--- a/app/src/main/java/com/laurelid/scanner/camera/CameraXAnalyzer.kt
+++ b/app/src/main/java/com/laurelid/scanner/camera/CameraXAnalyzer.kt
@@ -1,0 +1,56 @@
+package com.laurelid.scanner.camera
+
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import com.google.mlkit.vision.barcode.Barcode
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.common.InputImage
+import com.laurelid.util.Logger
+import com.laurelid.util.await
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+class CameraXAnalyzer(
+    private val scope: CoroutineScope,
+    private val barcodeScanner: BarcodeScanner,
+    private val onPayload: suspend (String) -> Unit,
+    private val shouldProcess: () -> Boolean,
+) : ImageAnalysis.Analyzer {
+
+    private var currentJob: Job? = null
+
+    override fun analyze(imageProxy: ImageProxy) {
+        if (!shouldProcess()) {
+            imageProxy.close()
+            return
+        }
+        val mediaImage = imageProxy.image ?: run {
+            imageProxy.close()
+            return
+        }
+        val inputImage = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+        currentJob?.cancel()
+        currentJob = scope.launch {
+            try {
+                val barcodes = barcodeScanner.process(inputImage).await()
+                val payload = barcodes.firstOrNull { barcode ->
+                    barcode.format == Barcode.FORMAT_QR_CODE && !barcode.rawValue.isNullOrBlank()
+                }?.rawValue
+                if (payload != null && shouldProcess()) {
+                    onPayload(payload)
+                }
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                Logger.e(TAG, "Barcode scanning failed", error)
+            } finally {
+                imageProxy.close()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "CameraXAnalyzer"
+    }
+}

--- a/app/src/main/java/com/laurelid/scanner/nfc/NfcHandler.kt
+++ b/app/src/main/java/com/laurelid/scanner/nfc/NfcHandler.kt
@@ -1,0 +1,75 @@
+package com.laurelid.scanner.nfc
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import android.nfc.NfcAdapter
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import com.laurelid.util.Logger
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
+
+class NfcHandler @Inject constructor() {
+
+    fun enableForegroundDispatch(
+        activity: androidx.appcompat.app.AppCompatActivity,
+        adapter: NfcAdapter?,
+        pendingIntent: PendingIntent?,
+        intentFilters: Array<IntentFilter>?,
+    ) {
+        if (adapter == null || !adapter.isEnabled) {
+            Logger.w(TAG, "NFC adapter not available or not enabled, cannot enable foreground dispatch.")
+            return
+        }
+        try {
+            adapter.enableForegroundDispatch(activity, pendingIntent, intentFilters, null)
+            Logger.i(TAG, "NFC foreground dispatch enabled.")
+        } catch (error: Exception) {
+            Logger.e(TAG, "Error enabling NFC foreground dispatch", error)
+        }
+    }
+
+    fun disableForegroundDispatch(activity: androidx.appcompat.app.AppCompatActivity, adapter: NfcAdapter?) {
+        try {
+            adapter?.disableForegroundDispatch(activity)
+            Logger.i(TAG, "NFC foreground dispatch disabled.")
+        } catch (error: IllegalStateException) {
+            Logger.w(TAG, "Failed to disable NFC foreground dispatch", error)
+        }
+    }
+
+    fun extractPayload(intent: Intent?): ByteArray? {
+        if (intent == null || intent.action != NfcAdapter.ACTION_NDEF_DISCOVERED) {
+            return null
+        }
+        if (intent.type != MDL_MIME_TYPE) {
+            Logger.w(TAG, "NFC intent received with incorrect MIME type: ${intent.type}")
+            return null
+        }
+        val messages: Array<NdefMessage>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES, NdefMessage::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)?.mapNotNull { it as? NdefMessage }?.toTypedArray()
+        }
+
+        val record = messages?.firstOrNull()?.records?.firstOrNull { candidate ->
+            candidate.tnf == NdefRecord.TNF_MIME_MEDIA &&
+                String(candidate.type, StandardCharsets.US_ASCII) == MDL_MIME_TYPE
+        }
+        return record?.payload
+    }
+
+    @VisibleForTesting
+    internal fun isMdocMimeType(type: ByteArray): Boolean {
+        return String(type, StandardCharsets.US_ASCII) == MDL_MIME_TYPE
+    }
+
+    companion object {
+        private const val TAG = "NfcHandler"
+        const val MDL_MIME_TYPE = "application/iso.18013-5+mdoc"
+    }
+}

--- a/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
@@ -2,12 +2,9 @@ package com.laurelid.ui
 
 import android.Manifest
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
-import android.nfc.NdefMessage
-import android.nfc.NdefRecord
 import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Bundle
@@ -24,6 +21,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -33,32 +31,28 @@ import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.mlkit.vision.barcode.BarcodeScanning // Ensured
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions // Changed to this specific import
-import com.google.mlkit.vision.barcode.common.Barcode // Kept as common
-import com.google.mlkit.vision.common.InputImage
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.laurelid.BuildConfig
 import com.laurelid.R
-import com.laurelid.auth.ISO18013Parser
-import com.laurelid.auth.MdocParseException
-import com.laurelid.auth.ParsedMdoc // Ensure this class exists and has necessary fields
-import com.laurelid.auth.VerifierService
-import com.laurelid.auth.WalletVerifier
 import com.laurelid.config.AdminConfig
 import com.laurelid.config.AdminPinManager
 import com.laurelid.config.ConfigManager
 import com.laurelid.config.EncryptedAdminPinStorage
-import com.laurelid.data.VerificationResult // Ensure this is Parcelable
 import com.laurelid.db.DbModule
-import com.laurelid.db.VerificationEntity
 import com.laurelid.kiosk.KioskWatchdogService
+import com.laurelid.data.VerificationResult
 import com.laurelid.network.TrustListApiFactory
 import com.laurelid.network.TrustListEndpointPolicy
 import com.laurelid.network.TrustListRepository
-import com.laurelid.pos.TransactionManager
+import com.laurelid.scanner.ScannerUiState
+import com.laurelid.scanner.ScannerViewModel
+import com.laurelid.scanner.camera.CameraXAnalyzer
+import com.laurelid.scanner.nfc.NfcHandler
 import com.laurelid.util.KioskUtil
-import com.laurelid.util.LogManager
 import com.laurelid.util.Logger
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +61,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -76,6 +69,8 @@ import javax.inject.Named
 
 @AndroidEntryPoint
 class ScannerActivity : AppCompatActivity() {
+
+    private val viewModel: ScannerViewModel by viewModels()
 
     private lateinit var previewView: PreviewView
     private lateinit var statusText: TextView
@@ -89,34 +84,27 @@ class ScannerActivity : AppCompatActivity() {
     lateinit var trustListRepository: TrustListRepository
 
     @Inject
-    lateinit var walletVerifier: WalletVerifier
-
-    @Inject
-    lateinit var logManager: LogManager
-
-    @Inject
     lateinit var trustListApiFactory: TrustListApiFactory
 
     @Inject
     @Named("trustListBaseUrl")
     lateinit var defaultTrustListBaseUrl: String
 
-    private val parser = ISO18013Parser()
+    @Inject
+    lateinit var nfcHandler: NfcHandler
+
     private val cameraExecutor: ExecutorService by lazy { Executors.newSingleThreadExecutor() }
     private val barcodeScanner by lazy {
         BarcodeScanning.getClient(
             BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .setBarcodeFormats(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_QR_CODE)
                 .build()
         )
     }
-
     private val verificationDao by lazy { DbModule.provideVerificationDao(applicationContext) }
-    private val transactionManager by lazy { TransactionManager() }
 
     private var cameraProvider: ProcessCameraProvider? = null
-    private var isProcessingCredential = false
-    private var currentState: ScannerState = ScannerState.SCANNING
+    private var imageAnalysis: ImageAnalysis? = null
     private var nfcAdapter: NfcAdapter? = null
     private var nfcPendingIntent: PendingIntent? = null
     private var nfcIntentFilters: Array<IntentFilter>? = null
@@ -125,9 +113,12 @@ class ScannerActivity : AppCompatActivity() {
     private var demoJob: Job? = null
     private var endpointUpdateJob: Job? = null
     private var nextDemoSuccess = true
+    private var cameraRunning = false
 
     private val adminTouchHandler = Handler(Looper.getMainLooper())
     private var adminDialogShowing = false
+
+    private var currentUiState: ScannerUiState = ScannerUiState()
 
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -151,6 +142,7 @@ class ScannerActivity : AppCompatActivity() {
         currentBaseUrl = trustListRepository.currentBaseUrl() ?: resolveBaseUrl(currentConfig)
 
         rebuildNetworkDependencies(currentConfig, true) // Force initial build
+        viewModel.updateConfig(currentConfig)
 
         KioskWatchdogService.start(this)
         enterLockTaskIfPermitted()
@@ -159,9 +151,15 @@ class ScannerActivity : AppCompatActivity() {
         bindViews()
         setupAdminGesture()
 
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { renderState(it) }
+            }
+        }
+
         if (!currentConfig.demoMode) {
             requestCameraPermission()
-            handleNfcIntent(intent) // Handle intent that started the activity
+            processNfcIntent(intent)
         }
     }
 
@@ -170,22 +168,17 @@ class ScannerActivity : AppCompatActivity() {
         val newConfig = configManager.getConfig()
         val configChanged = currentConfig != newConfig
         currentConfig = newConfig
+        viewModel.updateConfig(newConfig)
 
         rebuildNetworkDependencies(currentConfig, configChanged)
 
-
         if (currentConfig.demoMode) {
-            stopCamera()
-            startDemoMode()
             disableForegroundDispatch()
         } else {
-            stopDemoMode()
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
-                startCamera()
-            } else {
+            enableForegroundDispatch()
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
                 requestCameraPermission()
             }
-            enableForegroundDispatch()
         }
         KioskUtil.prepareForLockscreen(this)
         KioskUtil.setImmersiveMode(window)
@@ -199,9 +192,8 @@ class ScannerActivity : AppCompatActivity() {
             disableForegroundDispatch()
         }
         stopDemoMode()
+        stopCamera()
         KioskWatchdogService.notifyScannerVisible(false)
-        // No need to call stopCamera() explicitly if using ProcessCameraProvider,
-        // as it's lifecycle-aware. It will unbind when the lifecycle stops.
     }
 
     override fun onStop() {
@@ -215,7 +207,7 @@ class ScannerActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent) // Update the activity's intent
         if (!currentConfig.demoMode) {
-            handleNfcIntent(intent) // handleNfcIntent takes Intent?, so this is fine
+            processNfcIntent(intent)
         }
     }
 
@@ -253,7 +245,7 @@ class ScannerActivity : AppCompatActivity() {
         progressBar = findViewById(R.id.scannerProgress)
         debugButton = findViewById(R.id.debugLogButton)
 
-        updateState(ScannerState.SCANNING) // Initial state
+        applyUiState(ScannerUiState())
 
         if (BuildConfig.DEBUG) {
             debugButton.visibility = View.VISIBLE
@@ -277,6 +269,57 @@ class ScannerActivity : AppCompatActivity() {
             true // Consume event
         }
         rootLayout?.setOnTouchListener(touchListener)
+    }
+
+    private fun renderState(state: ScannerUiState) {
+        if (isFinishing) return
+        val previous = currentUiState
+        currentUiState = state
+        applyUiState(state)
+
+        when (state.phase) {
+            ScannerUiState.Phase.Verifying -> stopCamera()
+            ScannerUiState.Phase.Scanning -> {
+                if (!state.demoMode) {
+                    startCameraIfPermitted()
+                } else {
+                    stopCamera()
+                }
+            }
+            ScannerUiState.Phase.Result -> stopCamera()
+        }
+
+        if (state.demoMode) {
+            startDemoMode()
+        } else {
+            stopDemoMode()
+        }
+
+        state.result?.let {
+            if (previous.result != it) {
+                navigateToResult(it)
+                viewModel.onResultConsumed()
+            }
+        }
+
+        state.errorMessageRes?.let { resId ->
+            Toast.makeText(this, resId, Toast.LENGTH_LONG).show()
+            viewModel.onErrorConsumed()
+        }
+    }
+
+    private fun applyUiState(state: ScannerUiState) {
+        if (statusText.text != getString(state.statusTextRes)) {
+            statusText.animate()
+                .alpha(0f)
+                .setDuration(150)
+                .withEndAction {
+                    statusText.setText(state.statusTextRes)
+                    statusText.animate().alpha(1f).setDuration(150).start()
+                }.start()
+        }
+        hintText.text = getString(state.hintTextRes)
+        progressBar.visibility = if (state.showProgress) View.VISIBLE else View.INVISIBLE
     }
 
     private fun promptForAdminPin() {
@@ -375,7 +418,7 @@ class ScannerActivity : AppCompatActivity() {
         }
         when {
             ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED -> {
-                startCamera()
+                startCameraIfPermitted()
             }
             shouldShowRequestPermissionRationale(Manifest.permission.CAMERA) -> {
                 AlertDialog.Builder(this)
@@ -391,189 +434,82 @@ class ScannerActivity : AppCompatActivity() {
         }
     }
 
-    private fun startCamera() {
-        if (currentConfig.demoMode || isProcessingCredential) {
-            Logger.i(TAG, "Camera start prevented: demoMode=${currentConfig.demoMode}, isProcessing=$isProcessingCredential")
+    private fun startCameraIfPermitted() {
+        if (cameraRunning || currentConfig.demoMode) return
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
             return
         }
-        // Removed hasBoundCameras() check as unbindAll() is sufficient
+        startCamera()
+    }
+
+    private fun startCamera() {
+        if (cameraRunning || currentConfig.demoMode) {
+            Logger.i(TAG, "Camera start prevented: demoMode=${currentConfig.demoMode}, running=$cameraRunning")
+            return
+        }
 
         val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
         cameraProviderFuture.addListener({
-            try {
-                cameraProvider = cameraProviderFuture.get()
-            } catch (e: Exception) {
-                Logger.e(TAG, "Failed to get CameraProvider instance", e)
-                return@addListener
-            }
+            val provider = runCatching { cameraProviderFuture.get() }
+                .onFailure { Logger.e(TAG, "Failed to get CameraProvider instance", it) }
+                .getOrNull() ?: return@addListener
 
+            cameraProvider = provider
             val preview = Preview.Builder().build().also { it.setSurfaceProvider(previewView.surfaceProvider) }
-            val imageAnalysis = ImageAnalysis.Builder()
+            val analysis = ImageAnalysis.Builder()
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
 
-            imageAnalysis.setAnalyzer(cameraExecutor) { imageProxy ->
-                if (isProcessingCredential) { // Re-check before processing
-                    imageProxy.close()
-                    return@setAnalyzer
+            val analyzer = CameraXAnalyzer(
+                scope = lifecycleScope,
+                barcodeScanner = barcodeScanner,
+                onPayload = { payload -> viewModel.submitQrPayload(payload) },
+                shouldProcess = {
+                    !isFinishing && currentUiState.phase == ScannerUiState.Phase.Scanning && !currentUiState.demoMode
                 }
-                val mediaImage = imageProxy.image ?: run { imageProxy.close(); return@setAnalyzer }
-                val inputImage = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+            )
 
-                barcodeScanner.process(inputImage)
-                    .addOnSuccessListener { barcodes ->
-                        if (isProcessingCredential) return@addOnSuccessListener // Already handling one
-                        barcodes.firstOrNull { it.format == Barcode.FORMAT_QR_CODE && it.rawValue != null }
-                            ?.rawValue?.let { payload -> runOnUiThread { handleQrPayload(payload) } }
-                    }
-                    .addOnFailureListener { e -> Logger.e(TAG, "Barcode scanning failed", e) }
-                    .addOnCompleteListener { imageProxy.close() }
-            }
-            try {
-                cameraProvider?.unbindAll() // Unbind existing use cases before rebinding
-                cameraProvider?.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, preview, imageAnalysis)
+            analysis.setAnalyzer(cameraExecutor, analyzer)
+            imageAnalysis = analysis
+
+            runCatching {
+                provider.unbindAll()
+                provider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, preview, analysis)
+                cameraRunning = true
                 Logger.i(TAG, "Camera use cases bound to lifecycle.")
-            } catch (e: Exception) {
-                Logger.e(TAG, "Failed to bind camera use cases", e)
+            }.onFailure { error ->
+                Logger.e(TAG, "Failed to bind camera use cases", error)
+                analysis.clearAnalyzer()
             }
         }, ContextCompat.getMainExecutor(this))
     }
 
     private fun stopCamera() {
+        if (!cameraRunning) return
+        runCatching { imageAnalysis?.clearAnalyzer() }
         cameraProvider?.unbindAll()
+        cameraRunning = false
         Logger.i(TAG, "Camera unbound.")
     }
 
-    private fun handleQrPayload(payload: String) {
-        if (isProcessingCredential) {
+    private fun processNfcIntent(intent: Intent?) {
+        if (intent == null || currentConfig.demoMode) {
+            return
+        }
+        if (intent.action != NfcAdapter.ACTION_NDEF_DISCOVERED) {
+            return
+        }
+        if (currentUiState.isProcessing) {
             Toast.makeText(this, R.string.toast_processing, Toast.LENGTH_SHORT).show()
             return
         }
-        val isDemo = currentConfig.demoMode
-        val effectivePayload = if (isDemo) nextDemoPayload() else payload
-        Logger.i(TAG, if (isDemo) "Demo mode active; substituting simulated QR payload" else "QR payload received for verification")
-
-        isProcessingCredential = true
-        stopCamera() // Stop camera explicitly to free resources during verification
-        updateState(ScannerState.VERIFYING)
-        try {
-            // Assume parser.parseFromQrPayload is synchronous or handles its own threading
-            val parsedMdoc = parser.parseFromQrPayload(effectivePayload)
-            verifyAndPersist(parsedMdoc, isDemo)
-        } catch (error: MdocParseException) {
-            onCredentialParsingFailed("QR", error)
-        } catch (error: Exception) {
-            onCredentialParsingFailed("QR", error)
-        }
-    }
-
-    private fun handleNfcIntent(intent: Intent?) {
-        if (intent == null || currentConfig.demoMode || NfcAdapter.ACTION_NDEF_DISCOVERED != intent.action) {
-            return
-        }
-        if (intent.type != MDL_MIME_TYPE) {
-             Logger.w(TAG, "NFC intent received with incorrect MIME type: ${intent.type}")
-            return
-        }
-        if (isProcessingCredential) {
-            Toast.makeText(this, R.string.toast_processing, Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        val messages: Array<NdefMessage>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES, NdefMessage::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)?.mapNotNull { it as? NdefMessage }?.toTypedArray()
-        }
-
-        val record = messages?.firstOrNull()?.records?.firstOrNull { candidate ->
-            candidate.tnf == NdefRecord.TNF_MIME_MEDIA &&
-            String(candidate.type, StandardCharsets.US_ASCII) == MDL_MIME_TYPE // Use StandardCharsets
-        }
-        val payload = record?.payload
-
+        val payload = nfcHandler.extractPayload(intent)
         if (payload != null) {
             Logger.i(TAG, "NFC payload received for verification")
-            isProcessingCredential = true
-            stopCamera() // Stop camera when processing NFC
-            updateState(ScannerState.VERIFYING)
-            try {
-                val parsedMdoc = parser.parseFromNfc(payload) // Assume parseFromNfc exists and is similar to parseFromQrPayload
-                verifyAndPersist(parsedMdoc, demoPayloadUsed = false)
-            } catch (error: MdocParseException) {
-                onCredentialParsingFailed("NFC", error)
-            } catch (error: Exception) {
-                onCredentialParsingFailed("NFC", error)
-            }
+            viewModel.submitNfcPayload(payload)
         } else {
-            Toast.makeText(this, R.string.toast_nfc_error, Toast.LENGTH_LONG).show() // Ensure string exists
+            Toast.makeText(this, R.string.toast_nfc_error, Toast.LENGTH_LONG).show()
             Logger.w(TAG, "NFC NDEF message did not contain a valid mdoc payload.")
-        }
-    }
-
-    private fun onCredentialParsingFailed(source: String, error: Throwable) {
-        if (error is MdocParseException) {
-            Logger.w(TAG, "Failed to parse $source credential: ${error.error.detail}", error)
-        } else {
-            Logger.e(TAG, "Unexpected error while parsing $source credential", error)
-        }
-        showCredentialParsingErrorToast()
-        recoverFromProcessingFailure()
-    }
-
-    private fun showCredentialParsingErrorToast() {
-        Toast.makeText(this, R.string.result_details_error_unknown, Toast.LENGTH_LONG).show()
-    }
-
-    private fun recoverFromProcessingFailure() {
-        isProcessingCredential = false
-        updateState(ScannerState.SCANNING)
-        if (currentConfig.demoMode) {
-            if (demoJob?.isActive != true) {
-                startDemoMode()
-            }
-        } else {
-            val hasPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
-            if (hasPermission) {
-                startCamera()
-            } else {
-                requestCameraPermission()
-            }
-        }
-    }
-
-    private fun handleDemoPayload() {
-        if (!currentConfig.demoMode || isProcessingCredential) return
-        Logger.i(TAG, "Demo mode injecting simulated credential")
-        isProcessingCredential = true
-        stopCamera()
-        updateState(ScannerState.VERIFYING)
-        val parsedMdoc = parser.parseFromQrPayload(nextDemoPayload())
-        verifyAndPersist(parsedMdoc, demoPayloadUsed = true)
-    }
-
-    private fun verifyAndPersist(parsedMdoc: ParsedMdoc, demoPayloadUsed: Boolean) {
-        val configSnapshot = currentConfig // Use a snapshot of config for this verification
-        val refreshMillis = TimeUnit.MINUTES.toMillis(configSnapshot.trustRefreshIntervalMinutes.toLong())
-
-        lifecycleScope.launch {
-            val verifier = walletVerifier
-
-            val verificationResult = runCatching {
-                verifier.verify(parsedMdoc, refreshMillis)
-            }.getOrElse { throwable ->
-                Logger.e(TAG, "Verification failed with exception", throwable)
-                buildClientFailureResult(parsedMdoc)
-            }
-
-            val sanitizedResult = sanitizeResult(verificationResult)
-
-            persistResult(sanitizedResult, configSnapshot, demoPayloadUsed)
-            transactionManager.record(sanitizedResult) // Assuming TransactionManager.record exists
-            // transactionManager.printResult(verificationResult) // This seems for debugging, decide if needed
-
-            navigateToResult(sanitizedResult) // Navigate after all processing
         }
     }
 
@@ -585,50 +521,12 @@ class ScannerActivity : AppCompatActivity() {
         return resolved
     }
 
-    private fun updateState(state: ScannerState) {
-        if (state == currentState && !isFinishing) return // Avoid updates if already in state or finishing
-        currentState = state
-
-        val textRes = when (state) {
-            ScannerState.SCANNING -> R.string.scanner_status_scanning
-            ScannerState.VERIFYING -> R.string.scanner_status_verifying
-            ScannerState.RESULT -> R.string.scanner_status_ready // Or "Processed"
-        }
-        val hintRes = when (state) {
-            ScannerState.SCANNING -> R.string.scanner_hint
-            ScannerState.VERIFYING -> R.string.scanner_status_verifying // Or a "Verifying, please wait..."
-            ScannerState.RESULT -> R.string.scanner_status_ready // Or "Tap to scan next"
-        }
-
-        // Ensure UI updates are on the main thread, though animate() usually handles this.
-        runOnUiThread {
-            statusText.animate()
-                .alpha(0f)
-                .setDuration(150)
-                .withEndAction {
-                    statusText.setText(textRes) // Ensure string resources exist
-                    statusText.animate().alpha(1f).setDuration(150).start()
-                }.start()
-            hintText.text = getString(hintRes) // Ensure string resources exist
-            progressBar.visibility = if (state == ScannerState.VERIFYING) View.VISIBLE else View.INVISIBLE
-        }
-    }
-
     private fun navigateToResult(result: VerificationResult) {
         if (isFinishing) return
-        updateState(ScannerState.RESULT) // Update state before navigating
         val intent = Intent(this, ResultActivity::class.java).apply {
             putExtra(ResultActivity.EXTRA_VERIFICATION_RESULT, result) // Assuming ResultActivity.EXTRA_VERIFICATION_RESULT and VerificationResult is Parcelable
         }
         startActivity(intent)
-        isProcessingCredential = false // Reset for next scan if not finishing
-        if (!currentConfig.demoMode) { 
-            // If not finishing and not demo mode, restart camera
-            // requestCameraPermission() // This will call startCamera if needed.
-            // For now, let onResume handle camera restart if the activity is brought back to foreground.
-        } else if (currentConfig.demoMode) {
-            // Demo mode will auto-restart via its loop if still active.
-        }
     }
 
     private fun dumpLatestVerifications() {
@@ -638,50 +536,15 @@ class ScannerActivity : AppCompatActivity() {
         }
     }
 
-    private suspend fun persistResult(result: VerificationResult, config: AdminConfig, demoPayloadUsed: Boolean) {
-        withContext(Dispatchers.IO) {
-            val previous = verificationDao.mostRecent()
-            val successCount = (previous?.totalSuccessCount ?: 0) + if (result.success) 1 else 0
-            val failureCount = (previous?.totalFailureCount ?: 0) + if (result.success) 0 else 1
-            val over21Count = (previous?.totalAgeOver21Count ?: 0) + if (result.ageOver21 == true) 1 else 0
-            val under21Count = (previous?.totalAgeUnder21Count ?: 0) + if (result.ageOver21 == false) 1 else 0
-            val demoCount = (previous?.totalDemoModeCount ?: 0) + if (demoPayloadUsed) 1 else 0
-
-            val entity = VerificationEntity(
-                success = result.success,
-                ageOver21 = result.ageOver21 == true,
-                demoMode = demoPayloadUsed,
-                error = result.error,
-                tsMillis = System.currentTimeMillis(),
-                totalSuccessCount = successCount,
-                totalFailureCount = failureCount,
-                totalAgeOver21Count = over21Count,
-                totalAgeUnder21Count = under21Count,
-                totalDemoModeCount = demoCount,
-            )
-            verificationDao.insert(entity)
-            Logger.i(TAG, "Stored verification result (success=${result.success})")
-            logManager.appendVerification(result, config, demoPayloadUsed)
-        }
-    }
-
     private fun startDemoMode() {
         if (demoJob?.isActive == true) return
         Logger.i(TAG, "Starting demo mode loop")
-        stopCamera() // Ensure camera is stopped for demo mode
-        updateState(ScannerState.SCANNING) // Or a specific demo state
-        isProcessingCredential = false // Reset for demo loop
+        stopCamera()
         demoJob = lifecycleScope.launch {
-            while (isActive) {
+            while (isActive && currentConfig.demoMode) {
                 delay(DEMO_INTERVAL_MS)
-                if (!isActive) break // Check again after delay
-                if (isProcessingCredential) continue
-                if (currentConfig.demoMode) { // Ensure still in demo mode
-                    handleDemoPayload()
-                } else {
-                    stopDemoMode() // Exit if demo mode was turned off
-                    break
-                }
+                if (!isActive || !currentConfig.demoMode) break
+                viewModel.submitDemoPayload { nextDemoPayload() }
             }
         }
     }
@@ -689,9 +552,6 @@ class ScannerActivity : AppCompatActivity() {
     private fun stopDemoMode() {
         demoJob?.cancel()
         demoJob = null
-        if (currentState != ScannerState.VERIFYING) { // Only reset to scanning if not actively verifying
-            updateState(ScannerState.SCANNING)
-        }
     }
 
     private fun nextDemoPayload(): String {
@@ -710,40 +570,30 @@ class ScannerActivity : AppCompatActivity() {
             Logger.w(TAG, "NFC adapter not available or not enabled, cannot enable foreground dispatch.")
             return
         }
-        try {
-            if (nfcPendingIntent == null) {
-                val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                val flags = PendingIntent.FLAG_UPDATE_CURRENT or
-                        (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
-                nfcPendingIntent = PendingIntent.getActivity(this, 0, intent, flags)
-            }
-
-            if (nfcIntentFilters == null) {
-                val ndef = IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED).apply {
-                    try {
-                        addDataType(MDL_MIME_TYPE)
-                    } catch (e: IntentFilter.MalformedMimeTypeException) {
-                        Logger.e(TAG, "Failed to add NFC MIME type", e)
-                        throw RuntimeException("Failed to add NFC MIME type", e)
-                    }
-                    addCategory(Intent.CATEGORY_DEFAULT)
-                }
-                nfcIntentFilters = arrayOf(ndef)
-            }
-            nfcAdapter?.enableForegroundDispatch(this, nfcPendingIntent, nfcIntentFilters, null)
-            Logger.i(TAG, "NFC foreground dispatch enabled.")
-        } catch (e: Exception) {
-            Logger.e(TAG, "Error enabling NFC foreground dispatch", e)
+        if (nfcPendingIntent == null) {
+            val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            val flags = PendingIntent.FLAG_UPDATE_CURRENT or
+                (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
+            nfcPendingIntent = PendingIntent.getActivity(this, 0, intent, flags)
         }
+
+        if (nfcIntentFilters == null) {
+            val ndef = IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED).apply {
+                try {
+                    addDataType(NfcHandler.MDL_MIME_TYPE)
+                } catch (e: IntentFilter.MalformedMimeTypeException) {
+                    Logger.e(TAG, "Failed to add NFC MIME type", e)
+                    throw RuntimeException("Failed to add NFC MIME type", e)
+                }
+                addCategory(Intent.CATEGORY_DEFAULT)
+            }
+            nfcIntentFilters = arrayOf(ndef)
+        }
+        nfcHandler.enableForegroundDispatch(this, nfcAdapter, nfcPendingIntent, nfcIntentFilters)
     }
 
     private fun disableForegroundDispatch() {
-        try {
-            nfcAdapter?.disableForegroundDispatch(this)
-            Logger.i(TAG, "NFC foreground dispatch disabled.")
-        } catch (e: IllegalStateException) { // Can sometimes happen if activity is closing
-            Logger.w(TAG, "Failed to disable NFC foreground dispatch", e)
-        }
+        nfcHandler.disableForegroundDispatch(this, nfcAdapter)
     }
 
     private fun rebuildNetworkDependencies(config: AdminConfig, forceRebuild: Boolean) {
@@ -786,42 +636,14 @@ class ScannerActivity : AppCompatActivity() {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun currentBaseUrlForTest(): String? = currentBaseUrl
 
-    private enum class ScannerState { SCANNING, VERIFYING, RESULT }
-
     companion object {
         private const val TAG = "ScannerActivity"
-        private const val MDL_MIME_TYPE = "application/iso.18013-5+mdoc"
         private const val ADMIN_HOLD_DURATION_MS = 3000L // Reduced from 5s for easier testing
         private const val DEMO_INTERVAL_MS = 3000L // Interval for demo mode payloads
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal fun shouldEnterLockTask(config: AdminConfig, lockTaskPermitted: Boolean): Boolean {
             return !config.demoMode && lockTaskPermitted
-        }
-
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        internal fun buildClientFailureResult(parsedMdoc: ParsedMdoc): VerificationResult {
-            return VerificationResult(
-                success = false,
-                ageOver21 = parsedMdoc.ageOver21,
-                issuer = null,
-                subjectDid = null,
-                docType = parsedMdoc.docType,
-                error = VerifierService.ERROR_CLIENT_EXCEPTION,
-                trustStale = null,
-            )
-        }
-
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        internal fun sanitizeResult(result: VerificationResult): VerificationResult {
-            if (result.success) {
-                return result
-            }
-            return result.copy(
-                issuer = null,
-                subjectDid = null,
-                error = VerifierService.sanitizeReasonCode(result.error),
-            )
         }
     }
 }

--- a/app/src/main/java/com/laurelid/util/TasksExt.kt
+++ b/app/src/main/java/com/laurelid/util/TasksExt.kt
@@ -1,0 +1,20 @@
+package com.laurelid.util
+
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { continuation ->
+    addOnCompleteListener { task ->
+        if (continuation.isCancelled) return@addOnCompleteListener
+        val exception = task.exception
+        if (exception != null) {
+            continuation.resumeWithException(exception)
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            continuation.resume(task.result as T)
+        }
+    }
+    continuation.invokeOnCancellation { cancel() }
+}

--- a/app/src/test/java/com/laurelid/scanner/ScannerViewModelTest.kt
+++ b/app/src/test/java/com/laurelid/scanner/ScannerViewModelTest.kt
@@ -1,0 +1,129 @@
+package com.laurelid.scanner
+
+import com.laurelid.auth.MdocError
+import com.laurelid.auth.MdocParseException
+import com.laurelid.auth.ParsedMdoc
+import com.laurelid.config.AdminConfig
+import com.laurelid.data.VerificationResult
+import com.laurelid.scanner.CredentialParser
+import com.laurelid.scanner.ScannerUiState
+import com.laurelid.scanner.ScannerViewModel
+import com.laurelid.scanner.VerificationExecutor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScannerViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private val parsedMdoc = ParsedMdoc(
+        subjectDid = "did:example:123",
+        docType = "org.iso.18013.5.1.mDL",
+        issuer = "AZ-MVD",
+        ageOver21 = true,
+    )
+
+    private val verificationResult = VerificationResult(
+        success = true,
+        ageOver21 = true,
+        issuer = "AZ-MVD",
+        subjectDid = "did:example:123",
+        docType = "org.iso.18013.5.1.mDL",
+        error = null,
+        trustStale = false,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit QR payload transitions to result`() = runTest(dispatcher) {
+        val viewModel = ScannerViewModel(
+            credentialParser = FakeCredentialParser(parsedMdoc = parsedMdoc),
+            verificationExecutor = FakeVerificationExecutor(result = verificationResult),
+            dispatcher = dispatcher,
+        )
+
+        viewModel.updateConfig(AdminConfig())
+        viewModel.submitQrPayload("qr")
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(ScannerUiState.Phase.Result, state.phase)
+        assertEquals(verificationResult, state.result)
+        assertFalse(state.isProcessing)
+    }
+
+    @Test
+    fun `parser failure emits error state`() = runTest(dispatcher) {
+        val viewModel = ScannerViewModel(
+            credentialParser = FakeCredentialParser(throwOnQr = true),
+            verificationExecutor = FakeVerificationExecutor(result = verificationResult),
+            dispatcher = dispatcher,
+        )
+
+        viewModel.updateConfig(AdminConfig())
+        viewModel.submitQrPayload("bad")
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(ScannerUiState.Phase.Scanning, state.phase)
+        assertNull(state.result)
+        assertEquals(com.laurelid.R.string.result_details_error_unknown, state.errorMessageRes)
+        assertFalse(state.isProcessing)
+    }
+
+    private class FakeCredentialParser(
+        private val parsedMdoc: ParsedMdoc? = null,
+        private val throwOnQr: Boolean = false,
+    ) : CredentialParser {
+        override fun fromQr(payload: String): ParsedMdoc {
+            if (throwOnQr) {
+                throw MdocParseException(MdocError.Unexpected("bad payload"))
+            }
+            return parsedMdoc ?: error("parsedMdoc not provided")
+        }
+
+        override fun fromNfc(bytes: ByteArray): ParsedMdoc {
+            return parsedMdoc ?: error("parsedMdoc not provided")
+        }
+    }
+
+    private class FakeVerificationExecutor(
+        private val result: VerificationResult,
+    ) : VerificationExecutor {
+        override suspend fun verify(
+            parsedMdoc: ParsedMdoc,
+            config: AdminConfig,
+            demoPayloadUsed: Boolean,
+        ): VerificationResult {
+            return result
+        }
+
+        override fun buildClientFailureResult(parsedMdoc: ParsedMdoc): VerificationResult = result
+    }
+}

--- a/docs/scanner-class-diagram.md
+++ b/docs/scanner-class-diagram.md
@@ -1,0 +1,54 @@
+# Scanner Flow Class Diagram
+
+```mermaid
+classDiagram
+    class ScannerActivity {
+        +onCreate()
+        +renderState(state)
+        -startCameraIfPermitted()
+        -processNfcIntent(intent)
+    }
+
+    class ScannerViewModel {
+        +state: StateFlow<ScannerUiState>
+        +updateConfig(config)
+        +submitQrPayload(payload)
+        +submitNfcPayload(bytes)
+    }
+
+    class ScannerUiState {
+        +phase: Phase
+        +isProcessing: Boolean
+        +demoMode: Boolean
+        +result: VerificationResult?
+        +errorMessageRes: Int?
+    }
+
+    class VerificationExecutor {
+        <<interface>>
+        +verify(parsed, config, demo): VerificationResult
+        +buildClientFailureResult(parsed): VerificationResult
+    }
+
+    class VerificationOrchestrator {
+        +verify(parsed, config, demo)
+        +buildClientFailureResult(parsed)
+        -persistResult(...)
+    }
+
+    class CameraXAnalyzer {
+        +analyze(imageProxy)
+    }
+
+    class NfcHandler {
+        +enableForegroundDispatch(...)
+        +disableForegroundDispatch(...)
+        +extractPayload(intent): ByteArray?
+    }
+
+    ScannerActivity --> ScannerViewModel : observes state
+    ScannerActivity --> CameraXAnalyzer : configures
+    ScannerActivity --> NfcHandler : delegates NFC
+    ScannerViewModel --> VerificationExecutor : verifies credentials
+    VerificationOrchestrator ..|> VerificationExecutor
+```


### PR DESCRIPTION
## Summary
- replace ScannerActivity’s inline verification logic with a ScannerViewModel that exposes immutable ScannerUiState and collaborates with a VerificationExecutor implementation
- add modular helpers (CameraXAnalyzer, NfcHandler, credential parser binding, coroutine-based task awaiting) and document the relationships in a class diagram
- add Robolectric coverage for ScannerViewModel state transitions

## Testing
- `./gradlew test` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de18adc390832f96383c2caa126ffd