### PR TITLE
Revamp UI with modern gradient styling

### DIFF
--- a/app/src/main/java/com/laurelid/ui/ResultActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ResultActivity.kt
@@ -2,7 +2,6 @@ package com.laurelid.ui
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -11,8 +10,8 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import com.google.android.material.card.MaterialCardView
 import com.laurelid.R
 import com.laurelid.data.VerificationResult // Ensure this is Parcelable and has the necessary fields
 import com.laurelid.kiosk.KioskWatchdogService
@@ -81,23 +80,30 @@ class ResultActivity : AppCompatActivity() {
     private fun bindResult() {
         val result = verificationResult ?: return // Should not happen due to check in onCreate
 
-        val rootLayout: ConstraintLayout = findViewById(R.id.resultRoot)
         val titleView: TextView = findViewById(R.id.resultTitle)
         val detailView: TextView = findViewById(R.id.resultDetail)
         val issuerView: TextView = findViewById(R.id.resultIssuer)
         val iconView: TextView = findViewById(R.id.resultIcon)
+        val footerView: TextView = findViewById(R.id.resultFooter)
+        val cardView: MaterialCardView = findViewById(R.id.resultCard)
 
         if (result.success) {
-            rootLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.verification_success))
             iconView.text = "✓" // Checkmark symbol
             titleView.text = getString(R.string.result_verified)
+            titleView.setTextColor(ContextCompat.getColor(this, R.color.verification_success))
+            cardView.setStrokeColor(ContextCompat.getColor(this, R.color.verification_success))
+            footerView.text = getString(R.string.result_footer_success)
+            iconView.setTextColor(ContextCompat.getColor(this, R.color.verification_success))
             // Assuming ageOver21 is a boolean in VerificationResult
             val ageDetail = if (result.ageOver21 == true) "21+" else "Under 21" // Handle null case for ageOver21 if it's nullable
             detailView.text = getString(R.string.result_success_detail, ageDetail)
         } else {
-            rootLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.verification_failure))
             iconView.text = "✕" // X symbol
             titleView.text = getString(R.string.result_rejected)
+            titleView.setTextColor(ContextCompat.getColor(this, R.color.verification_failure))
+            cardView.setStrokeColor(ContextCompat.getColor(this, R.color.verification_failure))
+            footerView.text = getString(R.string.result_footer_failure)
+            iconView.setTextColor(ContextCompat.getColor(this, R.color.verification_failure))
             val errorDetail = result.error ?: getString(R.string.result_details_error_unknown)
             detailView.text = getString(R.string.result_failure_detail, errorDetail)
         }
@@ -106,7 +112,7 @@ class ResultActivity : AppCompatActivity() {
         issuerView.text = getString(R.string.result_issuer, issuerText)
 
         // Animate views after setting their initial text content
-        animateViews(iconView, titleView, detailView, issuerView)
+        animateViews(iconView, titleView, detailView, issuerView, footerView)
     }
 
     private fun animateViews(vararg views: View) { // Changed to View to be more generic

--- a/app/src/main/res/drawable/bg_app_gradient.xml
+++ b/app/src/main/res/drawable/bg_app_gradient.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gradient xmlns:android="http://schemas.android.com/apk/res/android"
+    android:type="linear"
+    android:angle="135"
+    android:startColor="@color/gradient_start"
+    android:centerColor="@color/gradient_center"
+    android:endColor="@color/gradient_end" />

--- a/app/src/main/res/drawable/bg_card_glass.xml
+++ b/app/src/main/res/drawable/bg_card_glass.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/card_surface" />
+    <corners android:radius="24dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/card_stroke" />
+</shape>

--- a/app/src/main/res/drawable/bg_input_field.xml
+++ b/app/src/main/res/drawable/bg_input_field.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#F2F4FF" />
+    <corners android:radius="18dp" />
+    <padding
+        android:left="16dp"
+        android:top="12dp"
+        android:right="16dp"
+        android:bottom="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_login_glow.xml
+++ b/app/src/main/res/drawable/bg_login_glow.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="280dp" android:height="280dp" />
+    <gradient
+        android:type="radial"
+        android:gradientRadius="180dp"
+        android:centerColor="#442AB4FF"
+        android:endColor="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/drawable/bg_primary_button.xml
+++ b/app/src/main/res/drawable/bg_primary_button.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/accent_glow">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/button_primary" />
+            <corners android:radius="28dp" />
+        </shape>
+    </item>
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/button_primary_pressed" />
+            <corners android:radius="28dp" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/bg_scanner_scrim.xml
+++ b/app/src/main/res/drawable/bg_scanner_scrim.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:startColor="#AA000000"
+        android:centerColor="#33000000"
+        android:endColor="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/layout/activity_admin.xml
+++ b/app/src/main/res/layout/activity_admin.xml
@@ -3,207 +3,232 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
+    android:background="@drawable/bg_app_gradient"
     android:contentDescription="@string/desc_admin_root"
     android:fillViewport="true">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:padding="24dp">
 
         <TextView
             android:id="@+id/adminTitle"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/admin_title"
             android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <EditText
-            android:id="@+id/venueIdInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_venue_id"
-            android:hint="@string/admin_venue_id"
-            android:inputType="text"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            app:layout_constraintTop_toBottomOf="@id/adminTitle"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <EditText
-            android:id="@+id/trustRefreshInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_trust_refresh"
-            android:hint="@string/admin_trust_refresh"
-            android:inputType="number"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            app:layout_constraintTop_toBottomOf="@id/venueIdInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <EditText
-            android:id="@+id/apiEndpointInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_api_endpoint"
-            android:hint="@string/admin_api_endpoint"
-            android:inputType="textUri"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            app:layout_constraintTop_toBottomOf="@id/trustRefreshInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            android:textSize="28sp"
+            android:textStyle="bold" />
 
         <TextView
-            android:id="@+id/apiEndpointLockedLabel"
-            android:layout_width="0dp"
+            android:id="@+id/adminDescription"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="@string/admin_api_endpoint_locked"
-            android:textColor="@android:color/white"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/apiEndpointInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            android:text="@string/admin_description"
+            android:textColor="@color/text_secondary_on_dark"
+            android:textSize="16sp" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/demoModeSwitch"
-            android:layout_width="wrap_content"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/adminFormCard"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="@string/admin_demo_mode"
-            android:textColor="@android:color/white"
-            android:textSize="20sp"
-            android:contentDescription="@string/admin_demo_mode"
-            android:minHeight="48dp"
-            android:paddingLeft="12dp"
-            android:paddingRight="12dp"
-            android:paddingTop="12dp"
-            android:paddingBottom="12dp"
-            app:layout_constraintTop_toBottomOf="@id/apiEndpointLockedLabel"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:cardBackgroundColor="@color/card_surface"
+            app:cardCornerRadius="28dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/card_stroke"
+            app:strokeWidth="1dp">
 
-        <TextView
-            android:id="@+id/pinSectionLabel"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:text="@string/admin_pin_section"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/demoModeSwitch"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingStart="24dp"
+                android:paddingTop="28dp"
+                android:paddingEnd="24dp"
+                android:paddingBottom="28dp">
 
-        <TextView
-            android:id="@+id/pinStatusText"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:textColor="@android:color/white"
-            android:accessibilityLiveRegion="polite"
-            app:layout_constraintTop_toBottomOf="@id/pinSectionLabel"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <TextView
+                    android:id="@+id/adminSectionLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/admin_venue_id"
+                    android:textAllCaps="true"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="13sp"
+                    android:letterSpacing="0.1"
+                    android:layout_marginBottom="8dp" />
 
-        <EditText
-            android:id="@+id/currentPinInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_pin_current_hint"
-            android:hint="@string/admin_pin_current_hint"
-            android:importantForAutofill="no"
-            android:inputType="numberPassword"
-            android:maxLength="12"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/pinStatusText"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <EditText
+                    android:id="@+id/venueIdInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_venue_id"
+                    android:hint="@string/admin_venue_id"
+                    android:inputType="text"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp" />
 
-        <EditText
-            android:id="@+id/newPinInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_pin_new_hint"
-            android:hint="@string/admin_pin_new_hint"
-            android:importantForAutofill="no"
-            android:inputType="numberPassword"
-            android:maxLength="12"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            app:layout_constraintTop_toBottomOf="@id/currentPinInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <TextView
+                    android:id="@+id/adminRefreshLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/admin_trust_refresh"
+                    android:textAllCaps="true"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="13sp"
+                    android:letterSpacing="0.1" />
 
-        <EditText
-            android:id="@+id/confirmPinInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@color/input_background"
-            android:contentDescription="@string/admin_pin_confirm_hint"
-            android:hint="@string/admin_pin_confirm_hint"
-            android:importantForAutofill="no"
-            android:inputType="numberPassword"
-            android:maxLength="12"
-            android:minHeight="48dp"
-            android:padding="16dp"
-            android:textSize="18sp"
-            android:textColor="@android:color/black"
-            android:textColorHint="@color/text_hint_on_light"
-            app:layout_constraintTop_toBottomOf="@id/newPinInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <EditText
+                    android:id="@+id/trustRefreshInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_trust_refresh"
+                    android:hint="@string/admin_trust_refresh"
+                    android:inputType="number"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp" />
 
-        <Button
-            android:id="@+id/saveButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:text="@string/admin_save"
-            android:contentDescription="@string/admin_save"
-            android:minHeight="56dp"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            app:layout_constraintTop_toBottomOf="@id/confirmPinInput"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <TextView
+                    android:id="@+id/adminEndpointLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/admin_api_endpoint"
+                    android:textAllCaps="true"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="13sp"
+                    android:letterSpacing="0.1" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <EditText
+                    android:id="@+id/apiEndpointInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_api_endpoint"
+                    android:hint="@string/admin_api_endpoint"
+                    android:inputType="textUri"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp" />
+
+                <TextView
+                    android:id="@+id/apiEndpointLockedLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/admin_api_endpoint_locked"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="14sp"
+                    android:visibility="gone" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/demoModeSwitch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="28dp"
+                    android:contentDescription="@string/admin_demo_mode"
+                    android:minHeight="48dp"
+                    android:padding="8dp"
+                    android:text="@string/admin_demo_mode"
+                    android:textColor="@android:color/white"
+                    android:textSize="20sp" />
+
+                <TextView
+                    android:id="@+id/pinSectionLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:text="@string/admin_pin_section"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold"
+                    android:textSize="20sp" />
+
+                <TextView
+                    android:id="@+id/pinStatusText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="16sp"
+                    android:accessibilityLiveRegion="polite" />
+
+                <EditText
+                    android:id="@+id/currentPinInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_pin_current_hint"
+                    android:hint="@string/admin_pin_current_hint"
+                    android:importantForAutofill="no"
+                    android:inputType="numberPassword"
+                    android:maxLength="12"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp"
+                    android:visibility="gone" />
+
+                <EditText
+                    android:id="@+id/newPinInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_pin_new_hint"
+                    android:hint="@string/admin_pin_new_hint"
+                    android:importantForAutofill="no"
+                    android:inputType="numberPassword"
+                    android:maxLength="12"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp" />
+
+                <EditText
+                    android:id="@+id/confirmPinInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/bg_input_field"
+                    android:contentDescription="@string/admin_pin_confirm_hint"
+                    android:hint="@string/admin_pin_confirm_hint"
+                    android:importantForAutofill="no"
+                    android:inputType="numberPassword"
+                    android:maxLength="12"
+                    android:minHeight="52dp"
+                    android:textColor="@android:color/black"
+                    android:textColorHint="@color/text_hint_on_light"
+                    android:textSize="18sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/saveButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:contentDescription="@string/admin_save"
+                    android:minHeight="56dp"
+                    android:text="@string/admin_save"
+                    android:textAllCaps="false"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    android:background="@drawable/bg_primary_button"
+                    android:textColor="@android:color/black" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,22 +3,108 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
+    android:background="@drawable/bg_app_gradient"
     android:contentDescription="@string/desc_login_root"
     android:padding="32dp">
 
-    <TextView
-        android:id="@+id/loginMessage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/login_placeholder"
-        android:textColor="@android:color/white"
-        android:textSize="28sp"
-        android:lineSpacingExtra="4sp"
-        android:gravity="center"
-        android:textAlignment="center"
-        android:importantForAccessibility="yes"
+    <View
+        android:id="@+id/loginGlow"
+        android:layout_width="260dp"
+        android:layout_height="260dp"
+        android:layout_marginTop="-64dp"
+        android:layout_marginEnd="-32dp"
+        android:alpha="0.65"
+        android:background="@drawable/bg_login_glow"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ImageView
+        android:id="@+id/loginIcon"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/bg_card_glass"
+        android:contentDescription="@null"
+        android:padding="18dp"
+        android:src="@android:drawable/ic_lock_idle_lock"
+        android:tint="@android:color/white"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/loginTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/login_title"
+        android:textColor="@android:color/white"
+        android:textSize="30sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/loginIcon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/loginTagline"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_tagline"
+        android:textColor="@color/text_secondary_on_dark"
+        android:textSize="18sp"
+        app:layout_constraintTop_toBottomOf="@id/loginTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/loginStatusCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="32dp"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="0dp"
+        app:cardUseCompatPadding="false"
+        app:layout_constraintTop_toBottomOf="@id/loginTagline"
+        app:layout_constraintBottom_toTopOf="@id/loginFooter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:strokeColor="@color/card_stroke"
+        app:strokeWidth="1dp"
+        app:cardBackgroundColor="@color/card_surface">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="32dp"
+            android:paddingTop="32dp"
+            android:paddingEnd="32dp"
+            android:paddingBottom="32dp"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/loginMessage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:lineSpacingExtra="6sp"
+                android:text="@string/login_placeholder"
+                android:textAlignment="center"
+                android:textColor="@android:color/white"
+                android:textSize="24sp"
+                android:importantForAccessibility="yes" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/loginFooter"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/login_footer"
+        android:textColor="@color/text_secondary_on_dark"
+        android:textSize="16sp"
+        android:lineSpacingExtra="4sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_result.xml
+++ b/app/src/main/res/layout/activity_result.xml
@@ -5,83 +5,114 @@
     android:id="@+id/resultRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
+    android:background="@drawable/bg_app_gradient"
     android:contentDescription="@string/desc_result_root"
     android:padding="32dp">
 
-    <TextView
-        android:id="@+id/resultIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:alpha="0.0"
-        android:contentDescription="@null"
-        android:importantForAccessibility="no"
-        android:text="✓"
-        android:textColor="@android:color/white"
-        android:textSize="120sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@+id/resultTitle"
-        app:layout_constraintEnd_toEndOf="parent"
+    <View
+        android:id="@+id/resultGlow"
+        android:layout_width="260dp"
+        android:layout_height="260dp"
+        android:layout_marginStart="-48dp"
+        android:layout_marginTop="-80dp"
+        android:alpha="0.6"
+        android:background="@drawable/bg_login_glow"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/resultCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        app:cardBackgroundColor="@color/card_surface"
+        app:cardCornerRadius="32dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/card_stroke"
+        app:strokeWidth="1dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        tools:layout_editor_absoluteX="156dp"
-        tools:layout_editor_absoluteY="414dp" />
+        app:layout_constraintBottom_toTopOf="@+id/resultFooter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingStart="32dp"
+            android:paddingTop="40dp"
+            android:paddingEnd="32dp"
+            android:paddingBottom="40dp">
+
+            <TextView
+                android:id="@+id/resultIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.0"
+                android:contentDescription="@null"
+                android:importantForAccessibility="no"
+                android:text="✓"
+                android:textColor="@android:color/white"
+                android:textSize="120sp"
+                android:textStyle="bold"
+                tools:text="✓" />
+
+            <TextView
+                android:id="@+id/resultTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.0"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:text="@string/result_verified"
+                android:textAlignment="center"
+                android:textColor="@color/verification_success"
+                android:textSize="42sp"
+                android:textStyle="bold"
+                android:accessibilityLiveRegion="polite"
+                tools:text="VERIFIED" />
+
+            <TextView
+                android:id="@+id/resultDetail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:alpha="0.0"
+                android:gravity="center"
+                android:layout_marginHorizontal="16dp"
+                android:textAlignment="center"
+                android:textColor="@android:color/white"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:accessibilityLiveRegion="polite" />
+
+            <TextView
+                android:id="@+id/resultIssuer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.0"
+                android:layout_marginTop="16dp"
+                android:layout_marginHorizontal="16dp"
+                android:gravity="center"
+                android:textAlignment="center"
+                android:textColor="@color/result_metadata"
+                android:textSize="16sp" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <TextView
-        android:id="@+id/resultTitle"
-        android:layout_width="wrap_content"
+        android:id="@+id/resultFooter"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:alpha="0.0"
-        android:text="@string/result_verified"
-        android:textColor="@color/verification_success"
-        android:textSize="48sp"
-        android:textStyle="bold"
-        android:accessibilityLiveRegion="polite"
-        android:layout_marginTop="16dp"
-        android:layout_marginBottom="12dp"
         android:gravity="center"
+        android:lineSpacingExtra="4sp"
+        android:text="@string/result_footer_success"
         android:textAlignment="center"
-        app:layout_constraintBottom_toTopOf="@+id/resultDetail"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:textColor="@color/text_secondary_on_dark"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/resultIcon"
-        tools:layout_editor_absoluteX="105dp"
-        tools:layout_editor_absoluteY="594dp" />
-
-    <TextView
-        android:id="@+id/resultDetail"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:alpha="0.0"
-        android:textColor="@android:color/white"
-        android:textSize="20sp"
-        android:textStyle="bold"
-        android:accessibilityLiveRegion="polite"
-        android:gravity="center"
-        android:layout_marginHorizontal="24dp"
-        android:textAlignment="center"
-        app:layout_constraintTop_toBottomOf="@id/resultTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:layout_editor_absoluteX="206dp"
-        tools:layout_editor_absoluteY="670dp" />
-
-    <TextView
-        android:id="@+id/resultIssuer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:alpha="0.0"
-        android:layout_marginTop="16dp"
-        android:layout_marginHorizontal="24dp"
-        android:gravity="center"
-        android:textAlignment="center"
-        android:textColor="@color/result_metadata"
-        android:textSize="18sp"
-        app:layout_constraintTop_toBottomOf="@id/resultDetail"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:layout_editor_absoluteX="206dp"
-        tools:layout_editor_absoluteY="710dp" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -4,7 +4,7 @@
     android:id="@+id/scannerRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
+    android:background="@drawable/bg_app_gradient"
     android:contentDescription="@string/desc_scanner_root">
 
     <androidx.camera.view.PreviewView
@@ -18,68 +18,119 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <View
+        android:id="@+id/scannerTopScrim"
+        android:layout_width="0dp"
+        android:layout_height="220dp"
+        android:background="@drawable/bg_scanner_scrim"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <LinearLayout
         android:id="@+id/overlayContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:gravity="center"
-        android:padding="24dp"
+        android:orientation="vertical"
+        android:padding="0dp"
         android:background="@android:color/transparent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <TextView
-            android:id="@+id/scannerStatus"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/scannerStatusCard"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/scanner_status_scanning"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:accessibilityLiveRegion="polite"
-            android:textAlignment="center"
-            android:gravity="center_horizontal" />
+            android:layout_margin="16dp"
+            app:cardBackgroundColor="@color/card_surface"
+            app:cardCornerRadius="28dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/card_stroke"
+            app:strokeWidth="1dp">
 
-        <TextView
-            android:id="@+id/scannerHint"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/scanner_hint"
-            android:textColor="@android:color/white"
-            android:textSize="18sp"
-            android:textAlignment="center"
-            android:gravity="center_horizontal"
-            android:labelFor="@id/previewView"
-            android:importantForAccessibility="yes" />
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:paddingStart="32dp"
+                android:paddingTop="32dp"
+                android:paddingEnd="32dp"
+                android:paddingBottom="32dp">
 
-        <ProgressBar
-            android:id="@+id/scannerProgress"
-            style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Large"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:contentDescription="@string/desc_scanner_progress"
-            android:indeterminate="true"
-            android:importantForAccessibility="yes" />
+                <TextView
+                    android:id="@+id/scannerStatus"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:text="@string/scanner_status_scanning"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="26sp"
+                    android:textStyle="bold"
+                    android:accessibilityLiveRegion="polite" />
 
-        <Button
-            android:id="@+id/debugLogButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/scanner_debug_button"
-            android:contentDescription="@string/desc_debug_log_button"
-            android:minHeight="48dp"
-            android:minWidth="88dp"
-            android:paddingLeft="24dp"
-            android:paddingRight="24dp"
-            android:paddingTop="12dp"
-            android:paddingBottom="12dp"
-            android:visibility="gone" />
+                <View
+                    android:layout_width="48dp"
+                    android:layout_height="3dp"
+                    android:layout_marginTop="16dp"
+                    android:background="@color/accent_glow" />
+
+                <TextView
+                    android:id="@+id/scannerHint"
+                    android:layout_width="220dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:gravity="center"
+                    android:labelFor="@id/previewView"
+                    android:text="@string/scanner_hint"
+                    android:textAlignment="center"
+                    android:textColor="@color/text_secondary_on_dark"
+                    android:textSize="18sp"
+                    android:importantForAccessibility="yes" />
+
+                <TextView
+                    android:id="@+id/scannerFooter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:gravity="center"
+                    android:text="@string/scanner_overlay_footer"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp" />
+
+                <ProgressBar
+                    android:id="@+id/scannerProgress"
+                    style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Large"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:contentDescription="@string/desc_scanner_progress"
+                    android:indeterminate="true"
+                    android:importantForAccessibility="yes" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/debugLogButton"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:minHeight="48dp"
+                    android:minWidth="220dp"
+                    android:text="@string/scanner_debug_button"
+                    android:textAllCaps="false"
+                    android:contentDescription="@string/desc_debug_log_button"
+                    android:visibility="gone"
+                    app:cornerRadius="24dp"
+                    app:strokeColor="@color/card_stroke"
+                    app:strokeWidth="1dp" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="gradient_start">#05070F</color>
+    <color name="gradient_center">#111E36</color>
+    <color name="gradient_end">#2A3B7A</color>
+    <color name="card_surface">#CC0A142F</color>
+    <color name="card_stroke">#40FFFFFF</color>
+    <color name="text_secondary_on_dark">#B3FFFFFF</color>
+    <color name="accent_glow">#4D3BDEFF</color>
+    <color name="button_primary">#45C7BE</color>
+    <color name="button_primary_pressed">#2C9E97</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,4 +12,15 @@
     <color name="input_background">#FFF4F4F4</color>
     <color name="text_hint_on_light">#FF5C5C5C</color>
     <color name="result_metadata">#FFC8C8C8</color>
+
+    <!-- Updated palette for immersive UI -->
+    <color name="gradient_start">#0C132C</color>
+    <color name="gradient_center">#192A52</color>
+    <color name="gradient_end">#3B4FD4</color>
+    <color name="card_surface">#CC101B3B</color>
+    <color name="card_stroke">#59FFFFFF</color>
+    <color name="text_secondary_on_dark">#CCFFFFFF</color>
+    <color name="accent_glow">#663BDEFF</color>
+    <color name="button_primary">#4EDDD4</color>
+    <color name="button_primary_pressed">#36B3AB</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="scanner_status_verifying">Verifying…</string>
     <string name="scanner_status_ready">Ready</string>
     <string name="scanner_hint">Align QR code or tap ID to reader</string>
+    <string name="scanner_overlay_footer">Privacy-first verification in progress.</string>
     <string name="scanner_debug_button">Dump recent logs</string>
     <string name="result_verified">VERIFIED</string>
     <string name="result_rejected">REJECTED</string>
@@ -13,11 +14,17 @@
     <string name="result_unknown_issuer">Unknown issuer</string>
     <string name="result_success_detail">Patron verified • %1$s</string>
     <string name="result_failure_detail">Unable to verify • %1$s</string>
+    <string name="result_footer_success">Access granted. Enjoy the experience!</string>
+    <string name="result_footer_failure">Please review the credential and try again.</string>
     <string name="login_placeholder">Operator login placeholder</string>
+    <string name="login_title">Welcome back</string>
+    <string name="login_tagline">Authenticate to unlock Laurel ID</string>
+    <string name="login_footer">Secure identity verification for modern venues.</string>
     <string name="error_camera_permission">Camera permission is required for scanning</string>
     <string name="toast_processing">Already processing credential…</string>
     <string name="toast_nfc_error">Unable to read NFC credential</string>
     <string name="admin_title">Administrator Settings</string>
+    <string name="admin_description">Fine-tune your device configuration and security controls.</string>
     <string name="admin_venue_id">Venue ID</string>
     <string name="admin_trust_refresh">Trust list refresh (minutes)</string>
     <string name="admin_api_endpoint">Trust list API endpoint override</string>


### PR DESCRIPTION
## Summary
- refresh the login, scanner, result, and admin screens with gradient backgrounds, glassmorphic cards, and refined typography
- add reusable drawable resources for gradients, glow accents, and input/button styling
- enhance the result screen logic to drive the new footer messaging and stroke accents for success and failure states

## Testing
- `./gradlew :app:lint` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05c89cd28832f921bff8d145cc997