### PR TITLE
Fix Kotlin toolchain config and kiosk back press handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,7 +103,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions { jvmTarget = "17" }
 
   // Optional: common packaging excludes (COSE/CBOR deps sometimes ship extra notices)
   packaging {
@@ -113,7 +112,10 @@ android {
   }
 }
 
-kotlin { jvmToolchain(17) }
+kotlin {
+  jvmToolchain(17)
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
 
 kapt { correctErrorTypes = true }
 
@@ -154,6 +156,6 @@ dependencies {
   implementation("com.google.mlkit:barcode-scanning:17.3.0")
 
   // Play Integrity
-  implementation("com.google.android.play:integrity:1.5.0")
+  implementation(libs.play.integrity)
   implementation("com.google.android.gms:play-services-tasks:18.4.0")
 }

--- a/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ScannerActivity.kt
@@ -20,6 +20,7 @@ import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
@@ -136,6 +137,7 @@ class ScannerActivity : AppCompatActivity() {
         KioskUtil.prepareForLockscreen(this)
         KioskUtil.applyKioskDecor(window)
         KioskUtil.blockBackPress(this)
+        onBackPressedDispatcher.addCallback(this) { /* kiosk: no-op */ }
 
         // Initialize ViewModel via ViewModelProvider (works with Hilt due to @AndroidEntryPoint)
         viewModel = ViewModelProvider(this)[ScannerViewModel::class.java]
@@ -243,10 +245,6 @@ class ScannerActivity : AppCompatActivity() {
     override fun onUserInteraction() {
         super.onUserInteraction()
         KioskUtil.setImmersiveMode(window)
-    }
-
-    override fun onBackPressed() {
-        // Kiosk mode: back press is blocked by KioskUtil or by not calling super.onBackPressed()
     }
 
     private fun bindViews() {
@@ -666,11 +664,7 @@ class ScannerActivity : AppCompatActivity() {
     private fun startWatchdogIfNeeded() {
         try {
             val intent = Intent(this, KioskWatchdogService::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                ContextCompat.startForegroundService(this, intent)
-            } else {
-                startService(intent)
-            }
+            ContextCompat.startForegroundService(this, intent)
             Logger.i(TAG, "Watchdog start requested from ScannerActivity.onStart()")
         } catch (t: Throwable) {
             Logger.w(TAG, "Deferred watchdog start failed; will retry later.", t)


### PR DESCRIPTION
## Summary
- switch the app module to the new Kotlin compilerOptions DSL and reuse the version catalog for Play Integrity
- add a no-op OnBackPressedDispatcher callback for kiosk mode and simplify the watchdog start path to rely on minSdk 26

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e463fe01b4832fb71669a5e2934317