### PR TITLE
Align build stack with AGP 9 and Android 14 guardrails

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 // app/build.gradle.kts
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")
@@ -114,7 +115,7 @@ android {
 
 kotlin {
   jvmToolchain(17)
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+  compilerOptions { jvmTarget.set(JvmTarget.JVM_17) }
 }
 
 kapt { correctErrorTypes = true }

--- a/app/src/main/java/com/laurelid/BootReceiver.kt
+++ b/app/src/main/java/com/laurelid/BootReceiver.kt
@@ -3,7 +3,6 @@ package com.laurelid
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.laurelid.kiosk.KioskWatchdogService
 import com.laurelid.ui.ScannerActivity
 import com.laurelid.util.Logger
 
@@ -11,7 +10,6 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         if (Intent.ACTION_BOOT_COMPLETED == intent?.action) {
             Logger.i(TAG, "Boot completed detected, launching scanner")
-            KioskWatchdogService.start(context)
             val launchIntent = Intent(context, ScannerActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }

--- a/app/src/main/java/com/laurelid/ui/ResultActivity.kt
+++ b/app/src/main/java/com/laurelid/ui/ResultActivity.kt
@@ -72,11 +72,6 @@ class ResultActivity : AppCompatActivity() {
         }
     }
 
-    override fun onBackPressed() {
-        // Disable back navigation while in kiosk mode.
-        // KioskUtil.blockBackPress(this) also handles this in onCreate.
-    }
-
     private fun bindResult() {
         val result = verificationResult ?: return // Should not happen due to check in onCreate
 

--- a/app/src/main/java/com/laurelid/util/Logger.kt
+++ b/app/src/main/java/com/laurelid/util/Logger.kt
@@ -1,12 +1,15 @@
 package com.laurelid.util
 
 import android.util.Log
+import com.laurelid.BuildConfig
 
 object Logger {
     private const val GLOBAL_TAG = "LaurelID"
 
     fun d(tag: String, message: String) {
-        Log.d("$GLOBAL_TAG:$tag", message)
+        if (BuildConfig.DEBUG) {
+            Log.d("$GLOBAL_TAG:$tag", message)
+        }
     }
 
     fun i(tag: String, message: String) {

--- a/baseline-profile-delete/build.gradle.kts
+++ b/baseline-profile-delete/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.android)
     id("com.android.test")
@@ -6,11 +8,11 @@ plugins {
 
 android {
     namespace = "com.laurelid.baselineprofile"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -23,10 +25,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildTypes {
         create("release") {
             matchingFallbacks += "release"
@@ -34,6 +32,13 @@ android {
         create("nonMinifiedRelease") {
             matchingFallbacks += "release"
         }
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
@@ -21,11 +22,17 @@ subprojects {
   plugins.withId("org.jetbrains.kotlin.android") {
     extensions.configure<KotlinAndroidProjectExtension> {
       jvmToolchain(17)
+      compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+      }
     }
   }
   plugins.withId("org.jetbrains.kotlin.jvm") {
     extensions.configure<KotlinJvmProjectExtension> {
       jvmToolchain(17)
+      compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+      }
     }
   }
 
@@ -44,7 +51,7 @@ subprojects {
   }
 
   dependencies {
-    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
+    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=36
 
 # org.gradle.configuration-cache=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "9.0.0"
 kotlin = "2.0.20"
 
 androidx-core = "1.17.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Sep 29 20:19:08 MST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,13 +5,14 @@ pluginManagement {
     mavenCentral()
   }
   plugins {
-    id("com.android.application") version "8.5.2"
+    id("com.android.application") version "9.0.0"
+    id("com.android.test") version "9.0.0"
     id("org.jetbrains.kotlin.android") version "2.0.20"
     id("org.jetbrains.kotlin.plugin.parcelize") version "2.0.20"
     id("org.jetbrains.kotlin.kapt") version "2.0.20"
     id("com.google.dagger.hilt.android") version "2.57.2"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
-    id("io.gitlab.arturbosch.detekt") version "1.23.6"
+    id("org.jlleitschuh.gradle.ktlint") version "13.1.0"
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
   }
 }
 


### PR DESCRIPTION
## Summary
- upgrade the wrapper, plugin management, and version catalog to Gradle 8.10.2 with AGP 9.0.0 and Kotlin 2.0.20
- enforce JVM 17 compilerOptions across modules and raise baseline-profile module to compile/target SDK 36
- remove foreground-service startup from the boot receiver, rely on dispatcher-based back handling, and restrict debug logging to debug builds

## Testing
- ./gradlew clean :app:assembleProductionDebug *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e46b4b8308832f986a15d89b12ed84